### PR TITLE
moving Helm artefacts from weaveworks to tofu-controller

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -9,7 +9,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.16.0-rc.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.16.0-rc.3.tgz
     version: 0.16.0-rc.3
   - apiVersion: v2
     appVersion: v0.16.0-rc.2
@@ -19,7 +19,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.16.0-rc.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.16.0-rc.2.tgz
     version: 0.16.0-rc.2
   - apiVersion: v2
     appVersion: v0.16.0-rc.1
@@ -29,7 +29,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.16.0-rc.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.16.0-rc.1.tgz
     version: 0.16.0-rc.1
   - apiVersion: v2
     appVersion: v0.16.0-dev
@@ -39,7 +39,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.16.0-dev.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.16.0-dev.tgz
     version: 0.16.0-dev
   - apiVersion: v2
     appVersion: v0.15.1
@@ -49,7 +49,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.15.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.15.1.tgz
     version: 0.15.1
   - apiVersion: v2
     appVersion: v0.15.0
@@ -59,7 +59,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.15.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.15.0.tgz
     version: 0.15.0
   - apiVersion: v2
     appVersion: v0.15.0-rc.6
@@ -69,7 +69,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.15.0-rc.6.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.15.0-rc.6.tgz
     version: 0.15.0-rc.6
   - apiVersion: v2
     appVersion: v0.15.0-rc.5
@@ -79,7 +79,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.15.0-rc.5.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.15.0-rc.5.tgz
     version: 0.15.0-rc.5
   - apiVersion: v2
     appVersion: v0.15.0-rc.4
@@ -89,7 +89,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.15.0-rc.4.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.15.0-rc.4.tgz
     version: 0.15.0-rc.4
   - apiVersion: v2
     appVersion: v0.15.0-rc.3
@@ -99,7 +99,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.15.0-rc.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.15.0-rc.3.tgz
     version: 0.15.0-rc.3
   - apiVersion: v2
     appVersion: v0.15.0-rc.1
@@ -109,7 +109,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.12.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.12.0.tgz
     version: 0.12.0
   - apiVersion: v2
     appVersion: v0.14.0
@@ -119,7 +119,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.11.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.11.0.tgz
     version: 0.11.0
   - apiVersion: v2
     appVersion: v0.13.1
@@ -129,7 +129,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.10.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.10.3.tgz
     version: 0.10.3
   - apiVersion: v2
     appVersion: v0.13.1
@@ -139,7 +139,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.10.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.10.2.tgz
     version: 0.10.2
   - apiVersion: v2
     appVersion: v0.13.1
@@ -149,7 +149,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.10.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.10.1.tgz
     version: 0.10.1
   - apiVersion: v2
     appVersion: v0.13.1
@@ -159,7 +159,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.10.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.10.0.tgz
     version: 0.10.0
   - apiVersion: v2
     appVersion: v0.13.1
@@ -169,7 +169,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.9.8.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.9.8.tgz
     version: 0.9.8
   - apiVersion: v2
     appVersion: v0.13.1
@@ -179,7 +179,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.9.6.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.9.6.tgz
     version: 0.9.6
   - apiVersion: v2
     appVersion: v0.13.1
@@ -189,7 +189,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.9.5.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.9.5.tgz
     version: 0.9.5
   - apiVersion: v2
     appVersion: v0.13.1
@@ -199,7 +199,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.9.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.9.3.tgz
     version: 0.9.3
   - apiVersion: v2
     appVersion: v0.13.1
@@ -209,7 +209,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.9.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.9.2.tgz
     version: 0.9.2
   - apiVersion: v2
     appVersion: v0.13.0
@@ -219,7 +219,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.9.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.9.1.tgz
     version: 0.9.1
   - apiVersion: v2
     appVersion: v0.13.0-rc.11
@@ -229,7 +229,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.9.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.9.0.tgz
     version: 0.9.0
   - apiVersion: v2
     appVersion: v0.13.0-rc.10
@@ -239,7 +239,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.9.0-dev.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.9.0-dev.2.tgz
     version: 0.9.0-dev.2
   - apiVersion: v2
     appVersion: v0.13.0-rc.10
@@ -249,7 +249,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.9.0-dev.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.9.0-dev.1.tgz
     version: 0.9.0-dev.1
   - apiVersion: v2
     appVersion: v0.13.0-rc.10
@@ -259,7 +259,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.8.9.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.8.9.tgz
     version: 0.8.9
   - apiVersion: v2
     appVersion: v0.13.0-rc.10
@@ -269,7 +269,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.8.8.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.8.8.tgz
     version: 0.8.8
   - apiVersion: v2
     appVersion: v0.13.0-rc.10
@@ -279,7 +279,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.8.6.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.8.6.tgz
     version: 0.8.6
   - apiVersion: v2
     appVersion: v0.13.0-rc.9
@@ -289,7 +289,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.8.5.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.8.5.tgz
     version: 0.8.5
   - apiVersion: v2
     appVersion: v0.13.0-rc.8
@@ -299,7 +299,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.8.4.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.8.4.tgz
     version: 0.8.4
   - apiVersion: v2
     appVersion: v0.13.0-rc.5
@@ -309,7 +309,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.8.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.8.3.tgz
     version: 0.8.3
   - apiVersion: v2
     appVersion: v0.13.0-rc.5
@@ -319,7 +319,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.8.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.8.2.tgz
     version: 0.8.2
   - apiVersion: v2
     appVersion: v0.13.0-rc.2
@@ -329,7 +329,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.8.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.8.1.tgz
     version: 0.8.1
   - apiVersion: v2
     appVersion: v0.13.0-rc.2
@@ -339,7 +339,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.8.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.8.0.tgz
     version: 0.8.0
   - apiVersion: v2
     appVersion: v0.13.0-rc.1
@@ -349,7 +349,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.7.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.7.1.tgz
     version: 0.7.1
   - apiVersion: v2
     appVersion: v0.13.0-rc.1
@@ -359,7 +359,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.7.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.7.0.tgz
     version: 0.7.0
   - apiVersion: v2
     appVersion: v0.12.0
@@ -369,7 +369,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.6.4.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.6.4.tgz
     version: 0.6.4
   - apiVersion: v2
     appVersion: v0.12.0-rc.6
@@ -379,7 +379,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.6.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.6.3.tgz
     version: 0.6.3
   - apiVersion: v2
     appVersion: v0.12.0-rc.5
@@ -389,7 +389,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.6.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.6.2.tgz
     version: 0.6.2
   - apiVersion: v2
     appVersion: v0.12.0-rc.4
@@ -399,7 +399,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.6.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.6.1.tgz
     version: 0.6.1
   - apiVersion: v2
     appVersion: v0.12.0-rc.3
@@ -409,7 +409,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.6.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.6.0.tgz
     version: 0.6.0
   - apiVersion: v2
     appVersion: v0.12.0-rc.2
@@ -419,7 +419,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.5.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.5.3.tgz
     version: 0.5.3
   - apiVersion: v2
     appVersion: v0.12.0-rc.2
@@ -429,7 +429,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.5.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.5.2.tgz
     version: 0.5.2
   - apiVersion: v2
     appVersion: v0.12.0-rc.1
@@ -439,7 +439,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.5.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.5.0.tgz
     version: 0.5.0
   - apiVersion: v2
     appVersion: v0.11.0
@@ -449,7 +449,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.4.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.4.3.tgz
     version: 0.4.3
   - apiVersion: v2
     appVersion: v0.11.0-rc.3
@@ -459,7 +459,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.4.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.4.2.tgz
     version: 0.4.2
   - apiVersion: v2
     appVersion: v0.11.0-rc.2
@@ -469,7 +469,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.4.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.4.1.tgz
     version: 0.4.1
   - apiVersion: v2
     appVersion: v0.11.0-rc.1
@@ -479,7 +479,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.4.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v2
     appVersion: v0.10.1
@@ -489,7 +489,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.9.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.9.tgz
     version: 0.3.9
   - apiVersion: v2
     appVersion: v0.10.0
@@ -499,7 +499,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.8.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.8.tgz
     version: 0.3.8
   - apiVersion: v2
     appVersion: v0.10.0-rc.8
@@ -509,7 +509,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.7.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.7.tgz
     version: 0.3.7
   - apiVersion: v2
     appVersion: v0.10.0-rc.7
@@ -519,7 +519,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.6.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.6.tgz
     version: 0.3.6
   - apiVersion: v2
     appVersion: v0.10.0-rc.6
@@ -529,7 +529,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.5.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.5.tgz
     version: 0.3.5
   - apiVersion: v2
     appVersion: v0.10.0-rc.5
@@ -539,7 +539,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.4.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.4.tgz
     version: 0.3.4
   - apiVersion: v2
     appVersion: v0.10.0-rc.5
@@ -549,7 +549,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.3.tgz
     version: 0.3.3
   - apiVersion: v2
     appVersion: v0.10.0-rc.3
@@ -559,7 +559,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.2.tgz
     version: 0.3.2
   - apiVersion: v2
     appVersion: v0.10.0-rc.2
@@ -569,7 +569,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.1.tgz
     version: 0.3.1
   - apiVersion: v2
     appVersion: v0.9.5
@@ -579,7 +579,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.3.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v2
     appVersion: v0.9.5-rc.3
@@ -589,7 +589,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.2.9.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.2.9.tgz
     version: 0.2.9
   - apiVersion: v2
     appVersion: v0.9.4
@@ -599,7 +599,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.2.8.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.2.8.tgz
     version: 0.2.8
   - apiVersion: v2
     appVersion: v0.9.3
@@ -609,7 +609,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.2.6.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.2.6.tgz
     version: 0.2.6
   - apiVersion: v2
     appVersion: v0.9.3
@@ -619,7 +619,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.2.5.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.2.5.tgz
     version: 0.2.5
   - apiVersion: v2
     appVersion: v0.9.2
@@ -629,7 +629,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.2.4.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.2.4.tgz
     version: 0.2.4
   - apiVersion: v2
     appVersion: v0.9.0
@@ -639,7 +639,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.2.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.2.3.tgz
     version: 0.2.3
   - apiVersion: v2
     appVersion: v0.9.0-rc.8
@@ -649,7 +649,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.2.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.2.2.tgz
     version: 0.2.2
   - apiVersion: v2
     appVersion: v0.9.0-rc.8
@@ -659,7 +659,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.2.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v2
     appVersion: v0.9.0-rc.8
@@ -669,7 +669,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.2.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v2
     appVersion: v0.9.0-rc.7
@@ -679,7 +679,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.9.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.9.tgz
     version: 0.1.9
   - apiVersion: v2
     appVersion: v0.9.0-rc.6
@@ -689,7 +689,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.8.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.8.tgz
     version: 0.1.8
   - apiVersion: v2
     appVersion: v0.9.0-rc.5
@@ -699,7 +699,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.7.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.7.tgz
     version: 0.1.7
   - apiVersion: v2
     appVersion: v0.9.0-rc.4
@@ -709,7 +709,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.6.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.6.tgz
     version: 0.1.6
   - apiVersion: v2
     appVersion: v0.9.0-rc.3
@@ -719,7 +719,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.5.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.5.tgz
     version: 0.1.5
   - apiVersion: v2
     appVersion: v0.9.0-rc.3
@@ -729,7 +729,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.4.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.4.tgz
     version: 0.1.4
   - apiVersion: v2
     appVersion: v0.9.0-rc.2
@@ -739,7 +739,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.3.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.3.tgz
     version: 0.1.3
   - apiVersion: v2
     appVersion: v0.9.0-rc.1
@@ -749,7 +749,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.2.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.2.tgz
     version: 0.1.2
   - apiVersion: v2
     appVersion: 0.8.0
@@ -759,7 +759,7 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.1.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.1.tgz
     version: 0.1.1
   - apiVersion: v2
     appVersion: 0.8.0
@@ -769,6 +769,6 @@ entries:
     name: tf-controller
     type: application
     urls:
-    - https://weaveworks.github.io/tf-controller/tf-controller-0.1.0.tgz
+    - https://flux-iac.github.io/tofu-controller/tf-controller-0.1.0.tgz
     version: 0.1.0
 generated: "2023-09-19T11:22:11.393220967Z"


### PR DESCRIPTION
This should fix the Helm repository index. 