### PR TITLE
Update URL for Helm Docs

### DIFF
--- a/charts/tf-controller/README.md
+++ b/charts/tf-controller/README.md
@@ -11,7 +11,7 @@ After that you can install TF-controller manually with Helm by:
 
 ```shell
 # Add tf-controller helm repository
-helm repo add tf-controller https://weaveworks.github.io/tf-controller/
+helm repo add tf-controller https://flux-iac.github.io/tofu-controller
 
 # Install tf-controller
 helm upgrade -i tf-controller tf-controller/tf-controller \


### PR DESCRIPTION
Just a quick fix to the docs to try and help clean things up after the switch and help newcomers get started properly. 