### PR TITLE
Helm chart url fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ release-manifests:
 # Helm
 SRC_ROOT = $(shell git rev-parse --show-toplevel)
 
-helm-docs: HELMDOCS_VERSION := v1.11.0
+helm-docs: HELMDOCS_VERSION := v1.13.0
 helm-docs: docker
 	@docker run -v "$(SRC_ROOT):/helm-docs" jnorwood/helm-docs:$(HELMDOCS_VERSION) --chart-search-root /helm-docs
 

--- a/charts/tf-controller/README.md
+++ b/charts/tf-controller/README.md
@@ -11,10 +11,10 @@ After that you can install TF-controller manually with Helm by:
 
 ```shell
 # Add tf-controller helm repository
-helm repo add tf-controller https://flux-iac.github.io/tofu-controller
+helm repo add tf-controller https://flux-iac.github.io/tofu-controller/
 
 # Install tf-controller
-helm upgrade -i tf-controller tf-controller/tf-controller \
+helm upgrade -i tofu-controller tofu-controller/tf-controller \
     --namespace flux-system
 ```
 
@@ -34,9 +34,9 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 | allowBreakTheGlass | bool | `false` | Argument for `--allow-break-the-glass` (Controller).  AllowBreakTheGlass allows the controller to break the glass and modify Terraform states when the sync loop is broken. |
 | allowCrossNamespaceRefs | bool | `false` | If `true`, enable cross-namespace references for controller and branch-planner |
 | awsPackage.install | bool | `true` |  |
-| awsPackage.repository | string | `"ghcr.io/tf-controller/aws-primitive-modules"` |  |
+| awsPackage.repository | string | `"ghcr.io/flux-iac/aws-primitive-modules"` |  |
 | awsPackage.tag | string | `"v4.38.0-v1alpha11"` |  |
-| branchPlanner | object | `{"configMap":"branch-planner","enabled":false,"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/weaveworks/branch-planner","tag":""},"podSecurityContext":{"fsGroup":1337},"pollingInterval":"30s","resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"200m","memory":"64Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}},"sourceInterval":"30s"}` | Branch Planner-specific configurations |
+| branchPlanner | object | `{"configMap":"branch-planner","enabled":false,"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/flux-iac/branch-planner","tag":""},"podSecurityContext":{"fsGroup":1337},"pollingInterval":"30s","resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"200m","memory":"64Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}},"sourceInterval":"30s"}` | Branch Planner-specific configurations |
 | caCertValidityDuration | string | `"168h0m"` | Argument for `--ca-cert-validity-duration` (Controller) |
 | certRotationCheckFrequency | string | `"30m0s"` | Argument for `--cert-rotation-check-frequency` (Controller) |
 | certValidityDuration | string | `"6h0m"` | Argument for `--cert-validity-duration` (Controller) |
@@ -49,7 +49,7 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 | extraEnv | object | `{}` | Additional container environment variables. |
 | fullnameOverride | string | `""` | Provide a fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Controller image pull policy |
-| image.repository | string | `"ghcr.io/weaveworks/tf-controller"` | Controller image repository |
+| image.repository | string | `"ghcr.io/flux-iac/tf-controller"` | Controller image repository |
 | image.tag | string | `.Chart.AppVersion` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Controller image pull secret |
 | installCRDs | bool | `true` | If `true`, install CRDs as part of the helm installation |
@@ -77,10 +77,10 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 | rbac.create | bool | `true` | If `true`, create and use RBAC resources |
 | replicaCount | int | `1` | Number of TF-Controller pods to deploy |
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"200m","memory":"64Mi"}}` | Resource limits and requests |
-| runner | object | `{"creationTimeout":"5m0s","grpc":{"maxMessageSize":4},"image":{"repository":"ghcr.io/weaveworks/tf-runner","tag":"v0.16.0-rc.3"},"serviceAccount":{"allowedNamespaces":[],"annotations":{},"create":true,"name":""}}` | Runner-specific configurations |
+| runner | object | `{"creationTimeout":"5m0s","grpc":{"maxMessageSize":4},"image":{"repository":"ghcr.io/flux-iac/tf-runner","tag":"v0.16.0-rc.3"},"serviceAccount":{"allowedNamespaces":[],"annotations":{},"create":true,"name":""}}` | Runner-specific configurations |
 | runner.creationTimeout | string | `"5m0s"` | Timeout for runner-creation (Controller) |
 | runner.grpc.maxMessageSize | int | `4` | Maximum GRPC message size (Controller) |
-| runner.image.repository | string | `"ghcr.io/weaveworks/tf-runner"` | Runner image repository |
+| runner.image.repository | string | `"ghcr.io/flux-iac/tf-runner"` | Runner image repository |
 | runner.image.tag | string | `.Chart.AppVersion` | Runner image tag |
 | runner.serviceAccount.allowedNamespaces | list | `[]` | List of namespaces that the runner may run within |
 | runner.serviceAccount.annotations | object | `{}` | Additional runner service Account annotations |
@@ -96,4 +96,4 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 | volumes | list | `[]` | Volumes properties for the TF-Controller deployment |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+Autogenerated from chart metadata using [helm-docs v1.13.0](https://github.com/norwoodj/helm-docs/releases/v1.13.0)

--- a/charts/tf-controller/README.md.gotmpl
+++ b/charts/tf-controller/README.md.gotmpl
@@ -11,10 +11,10 @@ After that you can install TF-controller manually with Helm by:
 
 ```shell
 # Add tf-controller helm repository
-helm repo add tf-controller https://weaveworks.github.io/tf-controller/
+helm repo add tf-controller https://flux-iac.github.io/tofu-controller/
 
 # Install tf-controller
-helm upgrade -i tf-controller tf-controller/tf-controller \
+helm upgrade -i tofu-controller tofu-controller/tf-controller \
     --namespace flux-system
 ```
 

--- a/charts/tf-controller/templates/packages.yaml
+++ b/charts/tf-controller/templates/packages.yaml
@@ -5,7 +5,7 @@ metadata:
   name: aws-package
   annotations:
     metadata.weave.works/description: "This is the AWS package containing primitive modules for Weave TF-controller."
-    metadata.weave.works/docs-url: "https://github.com/tf-controller/aws-primitive-modules"
+    metadata.weave.works/docs-url: "https://github.com/flux-iac/aws-primitive-modules"
 spec:
   interval: 1h0m0s
   ref:

--- a/charts/tf-controller/values.yaml
+++ b/charts/tf-controller/values.yaml
@@ -24,7 +24,7 @@ podLabels: {}
 replicaCount: 1
 image:
   # -- Controller image repository
-  repository: ghcr.io/weaveworks/tf-controller
+  repository: ghcr.io/flux-iac/tf-controller
   # -- Controller image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
@@ -111,12 +111,12 @@ usePodSubdomainResolution: false
 awsPackage:
   install: true
   tag: v4.38.0-v1alpha11
-  repository: ghcr.io/tf-controller/aws-primitive-modules
+  repository: ghcr.io/flux-iac/aws-primitive-modules
 # -- Runner-specific configurations
 runner:
   image:
     # -- Runner image repository
-    repository: ghcr.io/weaveworks/tf-runner
+    repository: ghcr.io/flux-iac/tf-runner
     # -- Runner image tag
     # @default -- `.Chart.AppVersion`
     tag: "v0.16.0-rc.3"
@@ -177,7 +177,7 @@ metrics:
 branchPlanner:
   enabled: false
   image:
-    repository: ghcr.io/weaveworks/branch-planner
+    repository: ghcr.io/flux-iac/branch-planner
     pullPolicy: IfNotPresent
     tag: ""
   configMap: branch-planner


### PR DESCRIPTION
This pr contains several updates to the helm chart:

- update image registry values to the new flux-iac organization
- update documentation metadata in chart to flux-iac pages
- update readme for the helm chart to contain these changes.

I havn't changed the chart version even though i think that would be the way to go. But since charts are currently linked to the controller versions i'll leave that up to the maintainers.

This solves the helm chart part of #1200 