### PR TITLE
config yaml renaming and docker file binary renamed

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -58,16 +58,16 @@ jobs:
             echo 'run make test and commit changes'
             exit 1
           fi
-      - name: Build the tf-controller container image
+      - name: Build the tofu-controller container image
         run: |
           VERSION="e2e-${GITHUB_SHA::8}"
           docker buildx use default
-          make docker-buildx MANAGER_IMG=test/tf-controller RUNNER_IMG=test/tf-runner TAG=$VERSION
+          make docker-buildx MANAGER_IMG=test/tofu-controller RUNNER_IMG=test/tf-runner TAG=$VERSION
       - name: Load test images into KIND
         run: |
           VERSION="e2e-${GITHUB_SHA::8}"
 
-          kind load docker-image test/tf-controller:$VERSION
+          kind load docker-image test/tofu-controller:$VERSION
           kind load docker-image test/tf-runner:$VERSION
       - name: Install CRDs
         run: make install
@@ -79,17 +79,17 @@ jobs:
           yq -i e ".spec.template.spec.containers[0].env[1].value=\"test/tf-runner:$VERSION\"" config/manager/manager.yaml
 
           # Dev deploy - do it twice to make sure the CRDs get in first
-          make dev-deploy MANAGER_IMG=test/tf-controller RUNNER_IMG=test/tf-runner TAG=$VERSION || true
-          make dev-deploy MANAGER_IMG=test/tf-controller RUNNER_IMG=test/tf-runner TAG=$VERSION
+          make dev-deploy MANAGER_IMG=test/tofu-controller RUNNER_IMG=test/tf-runner TAG=$VERSION || true
+          make dev-deploy MANAGER_IMG=test/tofu-controller RUNNER_IMG=test/tf-runner TAG=$VERSION
 
           # All of these old cert would be cleaned up by GC at the start of the test
-          kubectl -n tf-system apply -f config/testdata/gc-old-certs/test.yaml
+          kubectl -n tofu-system apply -f config/testdata/gc-old-certs/test.yaml
 
           # Increase the concurrency of the controller to speed up tests
           # --cert-rotation-check-frequency=6m0s, then GC will run every 1 minute
           kubectl patch deployment \
-            tf-controller \
-            --namespace tf-system \
+            tofu-controller \
+            --namespace tofu-system \
             --type='json' \
             -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args", "value": [
             "--watch-all-namespaces",
@@ -100,71 +100,71 @@ jobs:
             "--cert-rotation-check-frequency=6m0s",
           ]}]'
 
-          kubectl -n tf-system rollout status deploy/source-controller --timeout=1m
-          kubectl -n tf-system rollout status deploy/tf-controller --timeout=1m
+          kubectl -n tofu-system rollout status deploy/source-controller --timeout=1m
+          kubectl -n tofu-system rollout status deploy/tofu-controller --timeout=1m
       - name: Get terraform version
         run: |
-          # Terraform binary will be moved from the TF-controller image to TF-runner, so we check TF's version there
+          # Terraform binary will be moved from the ToFu-controller image to TF-runner, so we check TF's version there
           VERSION="e2e-${GITHUB_SHA::8}"
           docker run --rm --entrypoint=/usr/local/bin/terraform test/tf-runner:$VERSION version
       - name: Add git repository source
         run: |
-          kubectl -n tf-system apply -f ./config/testdata/source
-          kubectl -n tf-system wait gitrepository/helloworld --for=condition=ready --timeout=4m
-          kubectl -n tf-system wait ocirepository/helloworld-oci --for=condition=ready --timeout=4m
+          kubectl -n tofu-system apply -f ./config/testdata/source
+          kubectl -n tofu-system wait gitrepository/helloworld --for=condition=ready --timeout=4m
+          kubectl -n tofu-system wait ocirepository/helloworld-oci --for=condition=ready --timeout=4m
       - name: Run approvePlan tests
         run: |
-          kubectl -n tf-system apply -f ./config/testdata/approve-plan
-          kubectl -n tf-system wait terraform/helloworld-auto-approve --for=condition=ready --timeout=4m
-          kubectl -n tf-system wait terraform/helloworld-oci-auto-approve --for=condition=ready --timeout=4m
-          kubectl -n tf-system wait terraform/helloworld-manual-approve --for=condition=plan=true --timeout=4m
+          kubectl -n tofu-system apply -f ./config/testdata/approve-plan
+          kubectl -n tofu-system wait terraform/helloworld-auto-approve --for=condition=ready --timeout=4m
+          kubectl -n tofu-system wait terraform/helloworld-oci-auto-approve --for=condition=ready --timeout=4m
+          kubectl -n tofu-system wait terraform/helloworld-manual-approve --for=condition=plan=true --timeout=4m
 
           # delete after tests
-          kubectl -n tf-system delete -f ./config/testdata/approve-plan
+          kubectl -n tofu-system delete -f ./config/testdata/approve-plan
       - name: Run plan with pod cleanup tests
         run: |
-          kubectl -n tf-system apply -f ./config/testdata/always-clean-pod
-          kubectl -n tf-system wait terraform/helloworld-always-clean-pod-manual-approve --for=condition=plan=true --timeout=4m
+          kubectl -n tofu-system apply -f ./config/testdata/always-clean-pod
+          kubectl -n tofu-system wait terraform/helloworld-always-clean-pod-manual-approve --for=condition=plan=true --timeout=4m
 
           # negate pod not found to be true
-          ! kubectl -n tf-system get terraform/helloworld-always-clean-pod-manual-approve-tf-runner
+          ! kubectl -n tofu-system get terraform/helloworld-always-clean-pod-manual-approve-tf-runner
 
           # delete after tests
-          kubectl -n tf-system delete -f ./config/testdata/always-clean-pod
+          kubectl -n tofu-system delete -f ./config/testdata/always-clean-pod
       - name: Run drift detection tests
         run: |
-          kubectl -n tf-system apply -f ./config/testdata/drift-detection
+          kubectl -n tofu-system apply -f ./config/testdata/drift-detection
 
           # apply should be true first
-          kubectl -n tf-system wait terraform/helloworld-drift-detection --for=condition=apply=true --timeout=4m
+          kubectl -n tofu-system wait terraform/helloworld-drift-detection --for=condition=apply=true --timeout=4m
 
           # patch .spec.approvePlan to "disable"
-          kubectl -n tf-system patch terraform/helloworld-drift-detection -p '{"spec":{"approvePlan":"disable"}}' --type=merge
-          kubectl -n tf-system wait  terraform/helloworld-drift-detection --for=condition=ready=true --timeout=4m
+          kubectl -n tofu-system patch terraform/helloworld-drift-detection -p '{"spec":{"approvePlan":"disable"}}' --type=merge
+          kubectl -n tofu-system wait  terraform/helloworld-drift-detection --for=condition=ready=true --timeout=4m
 
           # disable drift detection
           # the object should work correctly
-          kubectl -n tf-system wait terraform/helloworld-drift-detection-disable --for=condition=ready --timeout=4m
+          kubectl -n tofu-system wait terraform/helloworld-drift-detection-disable --for=condition=ready --timeout=4m
 
           # delete after tests
-          kubectl -n tf-system delete -f ./config/testdata/drift-detection
+          kubectl -n tofu-system delete -f ./config/testdata/drift-detection
       - name: Run healthchecks tests
         run: |
-          kubectl -n tf-system apply -f ./config/testdata/healthchecks
-          kubectl -n tf-system wait terraform/helloworld-healthchecks --for=condition=ready --timeout=4m
+          kubectl -n tofu-system apply -f ./config/testdata/healthchecks
+          kubectl -n tofu-system wait terraform/helloworld-healthchecks --for=condition=ready --timeout=4m
 
           # delete after tests
-          kubectl -n tf-system delete -f ./config/testdata/healthchecks
+          kubectl -n tofu-system delete -f ./config/testdata/healthchecks
       - name: Run vars tests
         run: |
-          kubectl -n tf-system apply -f ./config/testdata/vars
-          kubectl -n tf-system wait terraform/helloworld-vars --for=condition=ready --timeout=4m
+          kubectl -n tofu-system apply -f ./config/testdata/vars
+          kubectl -n tofu-system wait terraform/helloworld-vars --for=condition=ready --timeout=4m
 
           # delete after tests
-          kubectl -n tf-system delete -f ./config/testdata/vars
+          kubectl -n tofu-system delete -f ./config/testdata/vars
       - name: Run multi-tenancy test
         run: |
-          kubectl -n tf-system scale --replicas=3 deploy/tf-controller
+          kubectl -n tofu-system scale --replicas=3 deploy/tf-controller
           kustomize build ./config/testdata/multi-tenancy/tenant01 | kubectl apply -f -
           kustomize build ./config/testdata/multi-tenancy/tenant02 | kubectl apply -f -
           kubectl -n tf-tenant01-dev wait terraform/helloworld-tenant01-dev --for=condition=ready --timeout=4m
@@ -190,7 +190,7 @@ jobs:
 
       - name: Set up chaos testing environment
         run: |
-          kubectl -n tf-system scale --replicas=0 deploy/tf-controller
+          kubectl -n tofu-system scale --replicas=0 deploy/tf-controller
           sleep 3
 
           kubectl -n chaos-testing apply -f ./config/testdata/chaos
@@ -199,7 +199,7 @@ jobs:
           # Set up namespace-scoped old certs for GC
           kubectl -n chaos-testing apply -f ./config/testdata/gc-old-certs/test.yaml
 
-          kubectl -n tf-system scale --replicas=1 deploy/tf-controller
+          kubectl -n tofu-system scale --replicas=1 deploy/tf-controller
 
           sleep 10
       - name: Randomly delete runner pods
@@ -232,32 +232,32 @@ jobs:
           (kubectl get secret terraform-runner.tls-8 -n chaos-testing >/dev/null 2>&1 && exit 1 || exit 0)
           (kubectl get secret terraform-runner.tls-9 -n chaos-testing >/dev/null 2>&1 && exit 1 || exit 0)
 
-          (kubectl get secret terraform-runner.tls-0 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
-          (kubectl get secret terraform-runner.tls-1 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
-          (kubectl get secret terraform-runner.tls-2 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
-          (kubectl get secret terraform-runner.tls-3 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
-          (kubectl get secret terraform-runner.tls-4 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
-          (kubectl get secret terraform-runner.tls-5 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
-          (kubectl get secret terraform-runner.tls-6 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
-          (kubectl get secret terraform-runner.tls-7 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
-          (kubectl get secret terraform-runner.tls-8 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
-          (kubectl get secret terraform-runner.tls-9 -n tf-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-0 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-1 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-2 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-3 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-4 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-5 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-6 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-7 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-8 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
+          (kubectl get secret terraform-runner.tls-9 -n tofu-system >/dev/null 2>&1 && exit 1 || exit 0)
 
           echo "All tests are true, all of the old secrets were GCed."
       - name: Logs
         run: |
-          kubectl -n tf-system logs deploy/source-controller
-          kubectl -n tf-system logs deploy/tf-controller
+          kubectl -n tofu-system logs deploy/source-controller
+          kubectl -n tofu-system logs deploy/tf-controller
       - name: Debug failure
         if: failure()
         run: |
           which kubectl
           kubectl version
           kustomize version
-          kubectl -n tf-system logs deploy/source-controller
-          kubectl -n tf-system logs deploy/tf-controller
+          kubectl -n tofu-system logs deploy/source-controller
+          kubectl -n tofu-system logs deploy/tf-controller
 
-          ns=(tf-system tf-tenant01-dev tf-tenant01-prd tf-tenant02-dev tf-tenant02-prd chaos-testing)
+          ns=(tofu-system tf-tenant01-dev tf-tenant01-prd tf-tenant02-dev tf-tenant02-prd chaos-testing)
           for n in "${ns[@]}"
           do
             kubectl -n $n get gitrepositories -oyaml          

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -164,7 +164,7 @@ jobs:
           kubectl -n tofu-system delete -f ./config/testdata/vars
       - name: Run multi-tenancy test
         run: |
-          kubectl -n tofu-system scale --replicas=3 deploy/tf-controller
+          kubectl -n tofu-system scale --replicas=3 deploy/tofu-controller
           kustomize build ./config/testdata/multi-tenancy/tenant01 | kubectl apply -f -
           kustomize build ./config/testdata/multi-tenancy/tenant02 | kubectl apply -f -
           kubectl -n tf-tenant01-dev wait terraform/helloworld-tenant01-dev --for=condition=ready --timeout=4m
@@ -190,7 +190,7 @@ jobs:
 
       - name: Set up chaos testing environment
         run: |
-          kubectl -n tofu-system scale --replicas=0 deploy/tf-controller
+          kubectl -n tofu-system scale --replicas=0 deploy/tofu-controller
           sleep 3
 
           kubectl -n chaos-testing apply -f ./config/testdata/chaos
@@ -199,7 +199,7 @@ jobs:
           # Set up namespace-scoped old certs for GC
           kubectl -n chaos-testing apply -f ./config/testdata/gc-old-certs/test.yaml
 
-          kubectl -n tofu-system scale --replicas=1 deploy/tf-controller
+          kubectl -n tofu-system scale --replicas=1 deploy/tofu-controller
 
           sleep 10
       - name: Randomly delete runner pods
@@ -247,7 +247,7 @@ jobs:
       - name: Logs
         run: |
           kubectl -n tofu-system logs deploy/source-controller
-          kubectl -n tofu-system logs deploy/tf-controller
+          kubectl -n tofu-system logs deploy/tofu-controller
       - name: Debug failure
         if: failure()
         run: |
@@ -255,7 +255,7 @@ jobs:
           kubectl version
           kustomize version
           kubectl -n tofu-system logs deploy/source-controller
-          kubectl -n tofu-system logs deploy/tf-controller
+          kubectl -n tofu-system logs deploy/tofu-controller
 
           ns=(tofu-system tf-tenant01-dev tf-tenant01-prd tf-tenant02-dev tf-tenant02-prd chaos-testing)
           for n in "${ns[@]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY utils/ utils/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
       go build -gcflags=all="-N -l" \
         -ldflags "-X main.BuildSHA='${BUILD_SHA}' -X main.BuildVersion='${BUILD_VERSION}'" \
-        -a -o tf-controller ./cmd/manager
+        -a -o tofu-controller ./cmd/manager
 
 FROM alpine:3.18
 
@@ -48,7 +48,7 @@ RUN apk update && \
     libretls \
     busybox
 
-COPY --from=builder /workspace/tf-controller /usr/local/bin/
+COPY --from=builder /workspace/tofu-controller /usr/local/bin/
 
 RUN addgroup --gid 65532 -S controller && adduser --uid 65532 -S controller -G controller
 
@@ -56,4 +56,4 @@ USER 65532:65532
 
 ENV GNUPGHOME=/tmp
 
-ENTRYPOINT [ "/sbin/tini", "--", "tf-controller" ]
+ENTRYPOINT [ "/sbin/tini", "--", "tofu-controller" ]

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 dev-deploy: manifests kustomize
 	mkdir -p config/dev && cp config/default/* config/dev
 	cd config/dev && $(KUSTOMIZE) edit set image ghcr.io/flux-iac/tofu-controller=${MANAGER_IMG}:${TAG}
-	$(KUSTOMIZE) build config/dev | yq e "select(.kind == \"Deployment\" and .metadata.name == \"tf-controller\").spec.template.spec.containers[0].env[1].value = \"test/tf-runner:$${TAG}\"" - | kubectl apply --server-side -f -
+	$(KUSTOMIZE) build config/dev | yq e "select(.kind == \"Deployment\" and .metadata.name == \"tofu-controller\").spec.template.spec.containers[0].env[1].value = \"test/tf-runner:$${TAG}\"" - | kubectl apply --server-side -f -
 	rm -rf config/dev
 
 # Delete dev deployment and CRDs

--- a/config/branch-planner/kustomization.yaml
+++ b/config/branch-planner/kustomization.yaml
@@ -6,6 +6,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 images:
-  - name: weaveworks/branch-planner
-    newName: ghcr.io/weaveworks/branch-planner
+  - name: flux-iac/branch-planner
+    newName: ghcr.io/flux-iac/branch-planner
     newTag: v0.16.0-rc.3

--- a/config/branch-planner/planner.yaml
+++ b/config/branch-planner/planner.yaml
@@ -2,27 +2,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/name: tf-controller-planner
-    app.kubernetes.io/instance: tf-controller
+    app.kubernetes.io/name: tofu-controller-planner
+    app.kubernetes.io/instance: tofu-controller
   name: branch-planner
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: tf-controller-planner
-      app.kubernetes.io/instance: tf-controller
+      app.kubernetes.io/name: tofu-controller-planner
+      app.kubernetes.io/instance: tofu-controller
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: tf-controller-planner
-        app.kubernetes.io/instance: tf-controller
+        app.kubernetes.io/name: tofu-controller-planner
+        app.kubernetes.io/instance: tofu-controller
     spec:
       containers:
       - args: []
         # Update the env variables according to your new deployment
-        image: "ghcr.io/weaveworks/branch-planner:v0.15.0-rc.5"
+        image: "ghcr.io/flux-iac/branch-planner:v0.15.0-rc.5"
         imagePullPolicy: IfNotPresent
-        name: tf-controller
+        name: tofu-controller
         ports:
         - containerPort: 8080
           name: http-prom

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: tf-system
+namespace: tofu-system
 resources:
 - https://github.com/fluxcd/source-controller/releases/download/v1.0.0-rc.1/source-controller.crds.yaml
 - https://github.com/fluxcd/source-controller/releases/download/v1.0.0-rc.1/source-controller.deployment.yaml

--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller
-  name: tf-system
+  name: tofu-system

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,6 +6,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 images:
-  - name: weaveworks/tf-controller
-    newName: ghcr.io/weaveworks/tf-controller
+  - name: flux-iac/tofu-controller
+    newName: ghcr.io/flux-iac/tofu-controller
     newTag: v0.16.0-rc.3

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,7 +18,7 @@ spec:
         control-plane: tofu-controller
     spec:
       terminationGracePeriodSeconds: 10
-      serviceAccountName: tofu-controller
+      serviceAccountName: tf-controller
       securityContext:
         fsGroup: 1337
       containers:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,33 +2,33 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tf-controller
+  name: tofu-controller
   labels:
-    control-plane: tf-controller
+    control-plane: tofu-controller
 spec:
   selector:
     matchLabels:
-      control-plane: tf-controller
+      control-plane: tofu-controller
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: tf-controller
+        control-plane: tofu-controller
     spec:
       terminationGracePeriodSeconds: 10
-      serviceAccountName: tf-controller
+      serviceAccountName: tofu-controller
       securityContext:
         fsGroup: 1337
       containers:
       - name: manager
-        image: weaveworks/tf-controller
+        image: flux-iac/tofu-controller
         imagePullPolicy: IfNotPresent
         command:
         - /sbin/tini
         - --
-        - tf-controller
+        - tofu-controller
         args:
         - --watch-all-namespaces
         - --log-level=info
@@ -47,7 +47,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RUNNER_POD_IMAGE
-          value: weaveworks/tf-runner
+          value: flux-iac/tf-runner
         securityContext:
           capabilities:
             drop: ["ALL"]

--- a/config/package/aws-package.yaml
+++ b/config/package/aws-package.yaml
@@ -5,6 +5,6 @@ metadata:
   name: aws-package
 spec:
   interval: 1h0m0s
-  url: oci://ghcr.io/tf-controller/aws-primitive-modules
+  url: oci://ghcr.io/flux-iac/aws-primitive-modules
   ref:
     tag: v4.38.0-v1alpha11

--- a/config/samples/infra_v1alpha2_terraform.yaml
+++ b/config/samples/infra_v1alpha2_terraform.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 30s
-  url: https://github.com/tf-controller/helloworld
+  url: https://github.com/flux-iac/helloworld
   ref:
     branch: main
 ---

--- a/config/testdata/multi-tenancy/base/test.yaml
+++ b/config/testdata/multi-tenancy/base/test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: helloworld
 spec:
   interval: 1m
-  url: https://github.com/tf-controller/helloworld.git
+  url: https://github.com/flux-iac/helloworld.git
   ref:
     branch: main
 ---

--- a/config/tilt/helm/dev-values.yaml
+++ b/config/tilt/helm/dev-values.yaml
@@ -1,6 +1,6 @@
 runner:
   image:
-    repository: ghcr.io/weaveworks/tf-runner
+    repository: ghcr.io/flux-iac/tf-runner
   serviceAccount:
     allowedNamespaces:
       - flux-system

--- a/config/tilt/test/tf-dev-subject.yaml
+++ b/config/tilt/test/tf-dev-subject.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: terraform
 spec:
   interval: 30s
-  url: https://github.com/tf-controller/helloworld
+  url: https://github.com/flux-iac/helloworld
   ref:
     branch: main
 ---
@@ -48,4 +48,4 @@ spec:
       labels:
         instance: helloworld-tf # This is the name of the Terraform resource
     spec:
-      image: ghcr.io/weaveworks/tf-runner
+      image: ghcr.io/flux-iac/tf-runner

--- a/local-e2e.sh
+++ b/local-e2e.sh
@@ -7,20 +7,20 @@ VERSION=e2e-$(git rev-parse --short HEAD)-$(if [[ $(git diff --stat) != '' ]]; t
 
 kind create cluster
 
-[[ -z "$SKIP_IMAGE_BUILD" ]] && make docker-build MANAGER_IMG=test/tf-controller RUNNER_IMG=test/tf-runner TAG=$VERSION # BUILD_ARGS="--no-cache"
+[[ -z "$SKIP_IMAGE_BUILD" ]] && make docker-build MANAGER_IMG=test/tofu-controller RUNNER_IMG=test/tf-runner TAG=$VERSION # BUILD_ARGS="--no-cache"
 
-kind load docker-image test/tf-controller:$VERSION
+kind load docker-image test/tofu-controller:$VERSION
 kind load docker-image test/tf-runner:$VERSION
 
 make install
 
 # Dev deploy
-make dev-deploy MANAGER_IMG=test/tf-controller RUNNER_IMG=test/tf-runner TAG=$VERSION || true
-make dev-deploy MANAGER_IMG=test/tf-controller RUNNER_IMG=test/tf-runner TAG=$VERSION
+make dev-deploy MANAGER_IMG=test/tofu-controller RUNNER_IMG=test/tf-runner TAG=$VERSION || true
+make dev-deploy MANAGER_IMG=test/tofu-controller RUNNER_IMG=test/tf-runner TAG=$VERSION
 
 kubectl patch deployment \
-  tf-controller \
-  --namespace tf-system \
+  tofu-controller \
+  --namespace tofu-system \
   --type='json' \
   -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args", "value": [
   "--watch-all-namespaces",
@@ -30,71 +30,71 @@ kubectl patch deployment \
   "--concurrent=10",
 ]}]'
 
-kubectl -n tf-system rollout status deploy/source-controller --timeout=1m
-kubectl -n tf-system rollout status deploy/tf-controller --timeout=1m
+kubectl -n tofu-system rollout status deploy/source-controller --timeout=1m
+kubectl -n tofu-system rollout status deploy/tofu-controller --timeout=1m
 
 echo "==================== Show Terraform version"
 docker run --rm --entrypoint=/usr/local/bin/terraform test/tf-runner:$VERSION version
 
 echo "==================== Add git repository source"
-kubectl -n tf-system apply -f ./config/testdata/source
-kubectl -n tf-system wait gitrepository/helloworld --for=condition=ready --timeout=4m
+kubectl -n tofu-system apply -f ./config/testdata/source
+kubectl -n tofu-system wait gitrepository/helloworld --for=condition=ready --timeout=4m
 
 echo "==================== Run approvePlan tests"
-kubectl -n tf-system apply -f ./config/testdata/approve-plan
-kubectl -n tf-system wait terraform/helloworld-auto-approve --for=condition=ready --timeout=4m
-kubectl -n tf-system wait terraform/helloworld-manual-approve --for=condition=plan=true --timeout=4m
+kubectl -n tofu-system apply -f ./config/testdata/approve-plan
+kubectl -n tofu-system wait terraform/helloworld-auto-approve --for=condition=ready --timeout=4m
+kubectl -n tofu-system wait terraform/helloworld-manual-approve --for=condition=plan=true --timeout=4m
 
 # delete after tests
-kubectl -n tf-system delete -f ./config/testdata/approve-plan
+kubectl -n tofu-system delete -f ./config/testdata/approve-plan
 
 echo "==================== Run plan with pod cleanup tests"
 
-kubectl -n tf-system apply -f ./config/testdata/always-clean-pod
-kubectl -n tf-system wait terraform/helloworld-always-clean-pod-manual-approve --for=condition=plan=true --timeout=4m
+kubectl -n tofu-system apply -f ./config/testdata/always-clean-pod
+kubectl -n tofu-system wait terraform/helloworld-always-clean-pod-manual-approve --for=condition=plan=true --timeout=4m
 
 # negate pod not found to be true
-! kubectl -n tf-system get terraform/helloworld-always-clean-pod-manual-approve-tf-runner
+! kubectl -n tofu-system get terraform/helloworld-always-clean-pod-manual-approve-tf-runner
 
 # delete after tests
-kubectl -n tf-system delete -f ./config/testdata/always-clean-pod
+kubectl -n tofu-system delete -f ./config/testdata/always-clean-pod
 
 echo "==================== Run drift detection tests"
 
-kubectl -n tf-system apply -f ./config/testdata/drift-detection
+kubectl -n tofu-system apply -f ./config/testdata/drift-detection
 
 # apply should be true first
-kubectl -n tf-system wait terraform/helloworld-drift-detection --for=condition=apply=true --timeout=4m
+kubectl -n tofu-system wait terraform/helloworld-drift-detection --for=condition=apply=true --timeout=4m
 
 # patch .spec.approvePlan to "disable"
-kubectl -n tf-system patch terraform/helloworld-drift-detection -p '{"spec":{"approvePlan":"disable"}}' --type=merge
-kubectl -n tf-system wait  terraform/helloworld-drift-detection --for=condition=ready=true  --timeout=4m
+kubectl -n tofu-system patch terraform/helloworld-drift-detection -p '{"spec":{"approvePlan":"disable"}}' --type=merge
+kubectl -n tofu-system wait  terraform/helloworld-drift-detection --for=condition=ready=true  --timeout=4m
 
 # disable drift detection
 # the object should work correctly
-kubectl -n tf-system wait terraform/helloworld-drift-detection-disable --for=condition=ready --timeout=4m
+kubectl -n tofu-system wait terraform/helloworld-drift-detection-disable --for=condition=ready --timeout=4m
 
 # delete after tests
-kubectl -n tf-system delete -f ./config/testdata/drift-detection
+kubectl -n tofu-system delete -f ./config/testdata/drift-detection
 
 echo "==================== Run healthchecks tests"
 
-kubectl -n tf-system apply -f ./config/testdata/healthchecks
-kubectl -n tf-system wait terraform/helloworld-healthchecks --for=condition=ready --timeout=4m
+kubectl -n tofu-system apply -f ./config/testdata/healthchecks
+kubectl -n tofu-system wait terraform/helloworld-healthchecks --for=condition=ready --timeout=4m
 
 # delete after tests
-kubectl -n tf-system delete -f ./config/testdata/healthchecks
+kubectl -n tofu-system delete -f ./config/testdata/healthchecks
 
 echo "==================== Run vars tests"
 
-kubectl -n tf-system apply -f ./config/testdata/vars
-kubectl -n tf-system wait terraform/helloworld-vars --for=condition=ready --timeout=4m
+kubectl -n tofu-system apply -f ./config/testdata/vars
+kubectl -n tofu-system wait terraform/helloworld-vars --for=condition=ready --timeout=4m
 
 # delete after tests
-kubectl -n tf-system delete -f ./config/testdata/vars
+kubectl -n tofu-system delete -f ./config/testdata/vars
 
 echo "==================== Run multi-tenancy test"
-kubectl -n tf-system scale --replicas=3 deploy/tf-controller
+kubectl -n tofu-system scale --replicas=3 deploy/tofu-controller
 kustomize build ./config/testdata/multi-tenancy/tenant01 | kubectl apply -f -
 kustomize build ./config/testdata/multi-tenancy/tenant02 | kubectl apply -f -
 kubectl -n tf-tenant01-dev wait terraform/helloworld-tenant01-dev --for=condition=ready --timeout=4m
@@ -119,7 +119,7 @@ kubectl delete ns tf-tenant02-dev
 kubectl delete ns tf-tenant02-prd
 
 echo "==================== Set up chaos testing environment"
-kubectl -n tf-system scale --replicas=1 deploy/tf-controller
+kubectl -n tofu-system scale --replicas=1 deploy/tofu-controller
 kubectl -n chaos-testing apply -f ./config/testdata/chaos
 kubectl -n chaos-testing apply -f ./config/testdata/source
 sleep 20


### PR DESCRIPTION
Rebranding/renaming to tofu-controller and flux-iac in /config

I've purposefully left service accounts alone, due to the way they are branded with kustomize resulting in also renaming the tf-runner accounts.

updated binary name in the docker file to tofu-controller.

Should fix #1215 and part of #1200