### PR TITLE
dockerfiles updated to alpine:3.19

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -46,13 +46,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - name: Build tf-controller image
+      - name: Build tofu-controller image
         run: |
           make docker-buildx
       - name: Run Trivy vulnerability scanner on controller image
         uses: aquasecurity/trivy-action@fbd16365eb88e12433951383f5e99bd901fc618f # v0.12.0
         with:
-          image-ref: 'ghcr.io/flux-iac/tf-controller:latest'
+          image-ref: 'ghcr.io/flux-iac/tofu-controller:latest'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
         -ldflags "-X main.BuildSHA='${BUILD_SHA}' -X main.BuildVersion='${BUILD_VERSION}'" \
         -a -o tofu-controller ./cmd/manager
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 LABEL org.opencontainers.image.source="https://github.com/flux-iac/tofu-controller"
 

--- a/planner.Dockerfile
+++ b/planner.Dockerfile
@@ -35,7 +35,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
       -o branch-planner \
       ./cmd/branch-planner
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 LABEL org.opencontainers.image.source="https://github.com/flux-iac/tofu-controller"
 

--- a/runner-azure.Dockerfile
+++ b/runner-azure.Dockerfile
@@ -16,8 +16,8 @@ RUN unzip -q /terraform_${TF_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/
 ARG AZCLI_VERSION=2.50.0
 RUN apk add --no-cache py3-pip && \
     apk add --no-cache gcc musl-dev python3-dev libffi-dev openssl-dev
-RUN pip install --upgrade pip && \
-    pip install azure-cli==${AZCLI_VERSION}
+RUN pip install --break-system-packages --upgrade pip && \
+    pip install azure-cli==${AZCLI_VERSION} --break-system-packages
 
 # Switch back to the non-root user after operations
 USER 65532:65532

--- a/runner-base.Dockerfile
+++ b/runner-base.Dockerfile
@@ -38,7 +38,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
         -o tf-runner \
         ./cmd/runner/main.go
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 LABEL org.opencontainers.image.source="https://github.com/flux-iac/tofu-controller"
 


### PR DESCRIPTION
Fixes #1219 

There is a but attached to this though.

updating to alpine 3.19 seems to have updated packages to a python version that follows [https://peps.python.org/pep-0668/](pep-668) which enforces python virtual environments.

The current implemented solution is to add the --break-system-packages flag to the commands. This basically bypasses pep-668 and locale2e tests passes, but it might be good to consider moving it to virtual environments instead.