### PR TITLE
fallback ghcr urls changed to flux-iac in runner

### DIFF
--- a/controllers/tc000260_runner_pod_test.go
+++ b/controllers/tc000260_runner_pod_test.go
@@ -25,7 +25,7 @@ func Test_000260_runner_pod_test(t *testing.T) {
 		terraformName      = "runner-pod-test"
 		sourceName         = "runner-pod-test"
 		serviceAccountName = "helloworld-tf-runner"
-		runnerPodImage     = "ghcr.io/weaveworks/tf-runner:test"
+		runnerPodImage     = "ghcr.io/flux-iac/tf-runner:test"
 		revision           = "v2.6@sha256:c7fd0cc69b924aa5f9a6928477311737e439ca1b9e444855b0377e8a8ec65bb5"
 	)
 

--- a/controllers/tf_controller_runner.go
+++ b/controllers/tf_controller_runner.go
@@ -32,7 +32,7 @@ func getRunnerPodImage(image string) string {
 		runnerPodImage = os.Getenv("RUNNER_POD_IMAGE")
 	}
 	if runnerPodImage == "" {
-		runnerPodImage = "ghcr.io/weaveworks/tf-runner:latest"
+		runnerPodImage = "ghcr.io/flux-iac/tf-runner:latest"
 	}
 	return runnerPodImage
 }


### PR DESCRIPTION
Changes the default url for the runner images to point to the flux-iac registry in the go code and test.

This fixes 2 tasks in #1200 