### PR TITLE
CLI: Reduce Binary Size

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,11 @@ builds:
     binary: tfctl
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
-      -  -X main.BuildSHA={{.ShortCommit}} -X main.BuildVersion={{.Tag}}
+      - -s -w
+      - -X main.BuildSHA={{.ShortCommit}} -X main.BuildVersion={{.Tag}}
     goos:
       - darwin
       - linux


### PR DESCRIPTION
This adds a Windows build for the CLI, and also reduces the resulting binary size by removing debug symbols.  The yield is about 30% reduction in size.
