### PR TITLE
Fix runner-serviceaccount helm template

### DIFF
--- a/charts/tf-controller/templates/runner-serviceaccount.yaml
+++ b/charts/tf-controller/templates/runner-serviceaccount.yaml
@@ -15,6 +15,7 @@ metadata:
 {{- with $.Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -24,6 +25,5 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: {{ include "tf-controller.runner.serviceAccountName" $ }}
 type: kubernetes.io/service-account-token
-{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The end statement for the custom imagePullSecrets is wrongly placed af the bottom of the yaml file. Instead it should be placed at the end of the ServiceAccount definition.