### PR TITLE
Add Aksel Skaar Leirvaag (@akselleirv) as a MAINTAINER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,7 @@
 Chanwit Kaewkasi <chanwit@gmail.com> (github: @chanwit)
 Balazs Nadasdi <efertone@pm.me> (github: @yitsushi)
 Tonni Follmann (github: @ilithanos)
+Aksel Skaar Leirvaag (github: @akselleirv)
 
 ### Emeritus Maintainers
 


### PR DESCRIPTION
Aksel Skaar Leirvaag has been a contributor from the early days of the project.
So, we are very happy to welcome Aksel (@akselleirv) as a new maintainer of Tofu-Controller 🎉 🎉

@akselleirv please
- approve this PR
- then merge it by yourself

Thank you and welcome to the team!