### PR TITLE
chainsaw: added poc test

### DIFF
--- a/test/data/terraform/hello-world-example/main.tf
+++ b/test/data/terraform/hello-world-example/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+}
+
+# website::tag::1:: The simplest possible Terraform module: it just outputs "Hello, World!"
+output "hello_world" {
+  value = "Hello, World!"
+}

--- a/test/no-outputs/chainsaw-test.yaml
+++ b/test/no-outputs/chainsaw-test.yaml
@@ -1,0 +1,88 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: no-outputs
+spec:
+  namespace: terraform
+  description: "This spec describes the behaviour of a Terraform resource with no backend, and `auto` approve."
+  steps:
+    - name: setup source
+      try:
+        - script:
+            content: (cd ../data/terraform/hello-world-example && oras push localhost:5000/hello-world-example:latest .)
+        - apply:
+            resource:
+              apiVersion: source.toolkit.fluxcd.io/v1beta2
+              kind: OCIRepository
+              metadata:
+                name: hello-world-example
+              spec:
+                interval: 1m
+                url: oci://kind-registry:5000/hello-world-example
+                insecure: true
+                ref:
+                  tag: latest
+    
+    - name: apply terraform
+      try:
+        - apply:
+            resource:
+              apiVersion: infra.contrib.fluxcd.io/v1alpha2
+              kind: Terraform
+              metadata:
+                name: no-outputs
+              spec:
+                approvePlan: auto
+                path: ./
+                sourceRef:
+                  kind: OCIRepository
+                  name: hello-world-example
+                  namespace: terraform
+                interval: 1m
+        
+    - name: assert plan conditions
+      try:
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: tfplan-default-no-outputs
+                annotations:
+                  (contains(savedPlan, 'plan-latest-')): true
+                  encoding: gzip
+              data:
+                (tfplan != null): true
+
+        - assert:
+            resource:
+              apiVersion: infra.contrib.fluxcd.io/v1alpha2
+              kind: Terraform
+              metadata:
+                name: no-outputs
+              status:
+                ~.(conditions[?type == 'Plan']):
+                  reason: "TerraformPlannedWithChanges"
+                  message: "Plan generated"
+
+    - name: assert apply conditions
+      try:
+        - assert:
+            resource:
+              apiVersion: infra.contrib.fluxcd.io/v1alpha2
+              kind: Terraform
+              metadata:
+                name: no-outputs
+              status:
+                ~.(conditions[?type == 'Apply']):
+                  reason: "TerraformAppliedSucceed"
+                  message: "Applied successfully"
+                availableOutputs:
+                  - hello_world
+      finally:
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: Secret
+              name: tfstate-default-no-outputs


### PR DESCRIPTION
Relates to https://github.com/flux-iac/tofu-controller/issues/1131

This is a rewrite of the main parts of the [controllers/tc000010_no_outputs_test.go](https://github.com/flux-iac/tofu-controller/blob/main/controllers/tc000010_no_outputs_test.go) test to showcase the benefits of [Chainsaw](https://github.com/kyverno/chainsaw).

Resources can be reused across the tests by placing the YAML manifests in a shared folder, instead of inlining them like I have done here. I find the declarative approach to testing much more readable compared to the more imperative Go test.

The current test uses `oras` to pack and push the OCI image to the local kind registry, but can be replaced with for example the `flux` CLI if we would like to avoid the dependency.
 
The test can be run with the following commands:

```bash
./tools/reboot.sh 
tilt up
chainsaw test test/no-outputs/
```

Is this approach something that could replace parts of the current controller test suite? Or would it be only be suitable for replacing the e2e tests?