### PR TITLE
feat: added support for tofu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ protoc-gen-go-grpc: ## Download controller-gen locally if necessary.
 CONTROLLER_GEN = $(GOBIN)/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0)
 
 # Find or download gen-crd-api-reference-docs
 GEN_CRD_API_REFERENCE_DOCS = $(GOBIN)/gen-crd-api-reference-docs

--- a/api/v1alpha2/terraform_types.go
+++ b/api/v1alpha2/terraform_types.go
@@ -270,6 +270,13 @@ type TerraformSpec struct {
 	// fails. The default is to not perform any action.
 	// +optional
 	Remediation *Remediation `json:"remediation,omitempty"`
+
+	// ExecType specifies the type of executable used for the operations.
+	// It can be either 'terraform' or 'tofu'.
+	// If not specified, the default is set based on the global configuration.
+	// +kubebuilder:validation:Enum=terraform;tofu
+	// +optional
+	ExecType string `json:"execType,omitempty"`
 }
 
 type BranchPlanner struct {

--- a/charts/tofu-controller/README.md
+++ b/charts/tofu-controller/README.md
@@ -49,6 +49,7 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 | eksSecurityGroupPolicy.create | bool | `false` | Create the EKS SecurityGroupPolicy |
 | eksSecurityGroupPolicy.ids | list | `[]` | List of AWS Security Group IDs |
 | eventsAddress | string | `"http://notification-controller.flux-system.svc.cluster.local./"` | Argument for `--events-addr` (Controller). The event address, default to the address of the Notification Controller |
+| execType | string | `"terraform"` | ExecType specifies the type of executable used for the operations. It can be either `terraform` or `tofu`. |
 | extraEnv | object | `{}` | Additional container environment variables. |
 | fullnameOverride | string | `""` | Provide a fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Controller image pull policy |

--- a/charts/tofu-controller/crds/crds.yaml
+++ b/charts/tofu-controller/crds/crds.yaml
@@ -1,13 +1,10 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: terraforms.infra.contrib.fluxcd.io
-  labels:
-    helm.sh/chart: tofu-controller-0.16.0-rc.4
-    app.kubernetes.io/version: 0.16.0-rc.4
 spec:
   group: infra.contrib.fluxcd.io
   names:
@@ -37,14 +34,19 @@ spec:
         description: Terraform is the Schema for the terraforms API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -56,9 +58,9 @@ spec:
                 description: Clean the runner pod up after each reconciliation cycle
                 type: boolean
               approvePlan:
-                description: ApprovePlan specifies name of a plan wanted to approve.
-                  If its value is "auto", the controller will automatically approve
-                  every plan.
+                description: |-
+                  ApprovePlan specifies name of a plan wanted to approve.
+                  If its value is "auto", the controller will automatically approve every plan.
                 type: string
               backendConfig:
                 description: BackendConfigSpec is for specifying configuration for
@@ -97,16 +99,17 @@ spec:
                       - ConfigMap
                       type: string
                     name:
-                      description: Name of the configs referent. Should reside in
-                        the same namespace as the referring resource.
+                      description: |-
+                        Name of the configs referent. Should reside in the same namespace as the
+                        referring resource.
                       maxLength: 253
                       minLength: 1
                       type: string
                     optional:
-                      description: Optional marks this BackendConfigsReference as
-                        optional. When set, a not found error for the values reference
-                        is ignored, but any Key or transient error will still result
-                        in a reconciliation failure.
+                      description: |-
+                        Optional marks this BackendConfigsReference as optional. When set, a not found error
+                        for the values reference is ignored, but any Key or
+                        transient error will still result in a reconciliation failure.
                       type: boolean
                   required:
                   - kind
@@ -114,12 +117,14 @@ spec:
                   type: object
                 type: array
               breakTheGlass:
-                description: BreakTheGlass specifies if the reconciliation should
-                  stop and allow interactive shell in case of emergency.
+                description: |-
+                  BreakTheGlass specifies if the reconciliation should stop
+                  and allow interactive shell in case of emergency.
                 type: boolean
               cliConfigSecretRef:
-                description: SecretReference represents a Secret Reference. It has
-                  enough information to retrieve secret in any namespace
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
                 properties:
                   name:
                     description: name is unique within a namespace to reference a
@@ -154,8 +159,9 @@ spec:
                 type: object
               dependsOn:
                 items:
-                  description: NamespacedObjectReference contains enough information
-                    to locate the referenced Kubernetes resource object in any namespace.
+                  description: |-
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
                   properties:
                     name:
                       description: Name of the referent.
@@ -174,14 +180,15 @@ spec:
                 type: boolean
               destroyResourcesOnDeletion:
                 default: false
-                description: Create destroy plan and apply it to destroy terraform
-                  resources upon deletion of this object. Defaults to false.
+                description: |-
+                  Create destroy plan and apply it to destroy terraform resources
+                  upon deletion of this object. Defaults to false.
                 type: boolean
               disableDriftDetection:
                 default: false
-                description: Disable automatic drift detection. Drift detection may
-                  be resource intensive in the context of a large cluster or complex
-                  Terraform statefile. Defaults to false.
+                description: |-
+                  Disable automatic drift detection. Drift detection may be resource intensive in
+                  the context of a large cluster or complex Terraform statefile. Defaults to false.
                 type: boolean
               enableInventory:
                 description: EnableInventory enables the object to store resource
@@ -226,19 +233,22 @@ spec:
                 type: array
               force:
                 default: false
-                description: Force instructs the controller to unconditionally re-plan
-                  and re-apply TF resources. Defaults to false.
+                description: |-
+                  Force instructs the controller to unconditionally
+                  re-plan and re-apply TF resources. Defaults to false.
                 type: boolean
               healthChecks:
                 description: List of health checks to be performed.
                 items:
-                  description: HealthCheck contains configuration needed to perform
-                    a health check after terraform is applied.
+                  description: |-
+                    HealthCheck contains configuration needed to perform a health check after
+                    terraform is applied.
                   properties:
                     address:
-                      description: Address to perform tcp health check on. Required
-                        when tcp type is specified. Go template can be used to reference
-                        values from the terraform output (e.g. 127.0.0.1:8080).
+                      description: |-
+                        Address to perform tcp health check on. Required when tcp type is specified.
+                        Go template can be used to reference values from the terraform output
+                        (e.g. 127.0.0.1:8080, {{.address}}:{{.port}}).
                       type: string
                     name:
                       description: Name of the health check.
@@ -247,22 +257,25 @@ spec:
                       type: string
                     timeout:
                       default: 20s
-                      description: The timeout period at which the connection should
-                        timeout if unable to complete the request. When not specified,
-                        default 20s timeout is used.
+                      description: |-
+                        The timeout period at which the connection should timeout if unable to
+                        complete the request.
+                        When not specified, default 20s timeout is used.
                       type: string
                     type:
-                      description: Type of the health check, valid values are ('tcp',
-                        'http'). If tcp is specified, address is required. If http
-                        is specified, url is required.
+                      description: |-
+                        Type of the health check, valid values are ('tcp', 'http').
+                        If tcp is specified, address is required.
+                        If http is specified, url is required.
                       enum:
                       - tcp
                       - http
                       type: string
                     url:
-                      description: URL to perform http health check on. Required when
-                        http type is specified. Go template can be used to reference
-                        values from the terraform output (e.g. https://example.org).
+                      description: |-
+                        URL to perform http health check on. Required when http type is specified.
+                        Go template can be used to reference values from the terraform output
+                        (e.g. https://example.org, {{.output_url}}).
                       type: string
                   required:
                   - name
@@ -279,7 +292,8 @@ spec:
                 format: int32
                 type: integer
               path:
-                description: Path to the directory containing Terraform (.tf) files.
+                description: |-
+                  Path to the directory containing Terraform (.tf) files.
                   Defaults to 'None', which translates to the root path of the SourceRef.
                 type: string
               readInputsFromSecrets:
@@ -300,7 +314,8 @@ spec:
                   the apply step.
                 type: boolean
               retryInterval:
-                description: The interval at which to retry a previously failed reconciliation.
+                description: |-
+                  The interval at which to retry a previously failed reconciliation.
                   The default value is 15 when not specified.
                 type: string
               runnerPodTemplate:
@@ -328,23 +343,20 @@ spec:
                               for the pod.
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node matches the corresponding matchExpressions;
-                                  the node(s) with the highest sum are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
-                                  description: An empty preferred scheduling term
-                                    matches all objects with implicit weight 0 (i.e.
-                                    it's a no-op). A null preferred scheduling term
-                                    matches no objects (i.e. is also a no-op).
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
                                     preference:
                                       description: A node selector term, associated
@@ -354,32 +366,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -392,32 +398,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -440,53 +440,46 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to an update), the system may or may not try
-                                  to eventually evict the pod from its node.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
                                       terms. The terms are ORed.
                                     items:
-                                      description: A null or empty node selector term
-                                        matches no objects. The requirements of them
-                                        are ANDed. The TopologySelectorTerm type implements
-                                        a subset of the NodeSelectorTerm.
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                       properties:
                                         matchExpressions:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -499,32 +492,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -547,19 +534,16 @@ spec:
                               other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -578,10 +562,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -589,20 +572,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -614,36 +593,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -651,20 +623,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -676,46 +644,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -724,25 +683,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to a pod label update), the system may or may
-                                  not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes
-                                  corresponding to each podAffinityTerm are intersected,
-                                  i.e. all terms must be satisfied.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -753,30 +709,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -788,53 +739,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -846,34 +789,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -887,19 +824,16 @@ spec:
                               etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the anti-affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity
-                                  expressions, etc.), compute a sum by iterating through
-                                  the elements of this field and adding "weight" to
-                                  the sum if the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -918,10 +852,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -929,20 +862,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -954,36 +883,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -991,20 +913,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1016,46 +934,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -1064,25 +973,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the anti-affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  anti-affinity requirements specified by this field
-                                  cease to be met at some point during pod execution
-                                  (e.g. due to a pod label update), the system may
-                                  or may not try to eventually evict the pod from
-                                  its node. When there are multiple elements, the
-                                  lists of nodes corresponding to each podAffinityTerm
-                                  are intersected, i.e. all terms must be satisfied.
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -1093,30 +999,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1128,53 +1029,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1186,34 +1079,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -1223,7 +1110,8 @@ spec:
                             type: object
                         type: object
                       env:
-                        description: List of environment variables to set in the container.
+                        description: |-
+                          List of environment variables to set in the container.
                           Cannot be updated.
                         items:
                           description: EnvVar represents an environment variable present
@@ -1234,16 +1122,16 @@ spec:
                                 be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables
-                                in the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. Double $$ are
-                                reduced to a single $, which allows for escaping the
-                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Defaults to "".'
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -1256,10 +1144,10 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -1270,11 +1158,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
                                       description: Version of the schema the FieldPath
@@ -1289,11 +1175,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -1323,10 +1207,10 @@ spec:
                                         from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -1342,13 +1226,13 @@ spec:
                           type: object
                         type: array
                       envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must
-                          be a C_IDENTIFIER. All invalid keys will be reported as
-                          an event when the container is starting. When a key exists
-                          in multiple sources, the value associated with the last
-                          source will take precedence. Values defined by an Env with
-                          a duplicate key will take precedence. Cannot be updated.
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -1357,9 +1241,10 @@ spec:
                               description: The ConfigMap to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must
@@ -1375,9 +1260,10 @@ spec:
                               description: The Secret to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be
@@ -1397,38 +1283,35 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The container
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The container image''s ENTRYPOINT is used
-                                if this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -1438,17 +1321,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -1461,10 +1343,10 @@ spec:
                                             description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -1475,11 +1357,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                         properties:
                                           apiVersion:
                                             description: Version of the schema the
@@ -1495,11 +1375,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -1531,10 +1409,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -1550,14 +1428,13 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -1566,10 +1443,10 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -1585,10 +1462,10 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -1599,44 +1476,42 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                This field is optional to allow higher level config
-                                management to default or override container images
-                                in workload controllers like Deployments and StatefulSets.'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
-                              description: Actions that the management system should
-                                take in response to container lifecycle events. Cannot
-                                be updated.
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -1646,8 +1521,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -1658,10 +1533,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -1679,24 +1553,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -1706,44 +1580,37 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -1753,8 +1620,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -1765,10 +1632,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -1786,24 +1652,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -1813,10 +1679,10 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -1824,30 +1690,29 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness.
-                                Container will be restarted if the probe fails. Cannot
-                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -1861,11 +1726,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -1875,9 +1741,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -1887,10 +1753,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -1907,34 +1772,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -1949,61 +1815,59 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL.
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
                                 Each container in a pod must have a unique name (DNS_LABEL).
                                 Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container.
-                                Not specifying a port here DOES NOT prevent that port
-                                from being exposed. Any port which is listening on
-                                the default "0.0.0.0" address inside a container will
-                                be accessible from the network. Modifying this array
-                                with strategic merge patch may corrupt the data. For
-                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                 Cannot be updated.
                               items:
                                 description: ContainerPort represents a network port
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -2011,23 +1875,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -2038,30 +1903,29 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness.
-                                Container will be removed from service endpoints if
-                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -2075,11 +1939,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -2089,9 +1954,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -2101,10 +1966,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -2121,34 +1985,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -2163,36 +2028,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -2203,14 +2065,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -2219,25 +2081,31 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -2253,8 +2121,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -2263,35 +2132,34 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             securityContext:
-                              description: 'SecurityContext defines the security options
-                                the container should be run with. If set, the fields
-                                of SecurityContext override the equivalent fields
-                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -2309,66 +2177,60 @@ spec:
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -2388,107 +2250,95 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must only be set if type is "Localhost".
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must only be set if type is "Localhost".
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        This field is alpha-level and will only be
-                                        honored by components that enable the WindowsHostProcessContainers
-                                        feature flag. Setting this field without the
-                                        feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be honored by components that enable the
+                                        WindowsHostProcessContainers feature flag. Setting this field without the feature
+                                        flag will result in errors when validating the Pod. All of a Pod's containers must
+                                        have the same effective HostProcess value (it is not allowed to have a mix of HostProcess
+                                        containers and non-HostProcess containers).  In addition, if HostProcess is true
+                                        then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has
-                                successfully initialized. If specified, no other probes
-                                are executed until this completes successfully. If
-                                this probe fails, the Pod will be restarted, just
-                                as if the livenessProbe failed. This can be used to
-                                provide different probe parameters at the beginning
-                                of a Pod''s lifecycle, when it might take a long time
-                                to load data or warm a cache, than during steady-state
-                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -2502,11 +2352,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -2516,9 +2367,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -2528,10 +2379,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -2548,34 +2398,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -2590,83 +2441,75 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -2691,44 +2534,44 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -2736,10 +2579,11 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
@@ -2753,42 +2597,39 @@ spec:
                       tolerations:
                         description: Set the Tolerations for the Runner Pod
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -2799,34 +2640,36 @@ spec:
                             within a container.
                           properties:
                             mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
                               type: string
                             name:
                               description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                           - mountPath
@@ -2840,37 +2683,36 @@ spec:
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'awsElasticBlockStore represents an AWS
-                                Disk resource that is attached to a kubelet''s host
-                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly value true will force the
-                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: 'volumeID is unique ID of the persistent
-                                    disk resource in AWS (Amazon EBS volume). More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
@@ -2892,10 +2734,10 @@ spec:
                                     the blob storage
                                   type: string
                                 fsType:
-                                  description: fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
                                   description: 'kind expected values are Shared: multiple
@@ -2905,9 +2747,9 @@ spec:
                                     set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
@@ -2918,9 +2760,9 @@ spec:
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
                                   description: secretName is the  name of secret that
@@ -2938,8 +2780,9 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'monitors is Required: Monitors is
-                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
@@ -2949,67 +2792,72 @@ spec:
                                     is /'
                                   type: string
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: 'secretFile is Optional: SecretFile
-                                    is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: 'secretRef is Optional: SecretRef is
-                                    reference to the authentication secret for User,
-                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is optional: User is the rados
-                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'cinder represents a cinder volume attached
-                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Examples: "ext4", "xfs", "ntfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: 'readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is optional: points to a
-                                    secret object containing parameters used to connect
-                                    to OpenStack.'
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: 'volumeID used to identify the volume
-                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
@@ -3019,30 +2867,25 @@ spec:
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items if unspecified, each key-value
-                                    pair in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -3051,25 +2894,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -3077,9 +2916,10 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: optional specify whether the ConfigMap
@@ -3093,45 +2933,43 @@ spec:
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: driver is the name of the CSI driver
-                                    that handles this volume. Consult with your admin
-                                    for the correct name as registered in the cluster.
+                                  description: |-
+                                    driver is the name of the CSI driver that handles this volume.
+                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: fsType to mount. Ex. "ext4", "xfs",
-                                    "ntfs". If not provided, the empty value is passed
-                                    to the associated CSI driver which will determine
-                                    the default filesystem to apply.
+                                  description: |-
+                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated CSI driver
+                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: nodePublishSecretRef is a reference
-                                    to the secret object containing sensitive information
-                                    to pass to the CSI driver to complete the CSI
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no
-                                    secret is required. If the secret object contains
-                                    more than one secret, all secret references are
-                                    passed.
+                                    This field is optional, and  may be empty if no secret is required. If the
+                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: readOnly specifies a read-only configuration
-                                    for the volume. Defaults to false (read/write).
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: volumeAttributes stores driver-specific
-                                    properties that are passed to the CSI driver.
-                                    Consult your driver's documentation for supported
-                                    values.
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
@@ -3141,17 +2979,15 @@ spec:
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits to use on created
-                                    files by default. Must be a Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    Optional: mode bits to use on created files by default. Must be a
+                                    Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
@@ -3181,16 +3017,13 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file, must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
@@ -3201,10 +3034,9 @@ spec:
                                           the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -3232,121 +3064,125 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'emptyDir represents a temporary directory
-                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: 'medium represents what type of storage
-                                    medium should back this directory. The default
-                                    is "" which means to use the node''s default medium.
-                                    Must be an empty string (default) or Memory. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    medium represents what type of storage medium should back this directory.
+                                    The default is "" which means to use the node's default medium.
+                                    Must be an empty string (default) or Memory.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'sizeLimit is the total amount of local
-                                    storage required for this EmptyDir volume. The
-                                    size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would
-                                    be the minimum value between the SizeLimit specified
-                                    here and the sum of memory limits of all containers
-                                    in a pod. The default is nil which means that
-                                    the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                    The size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would be the minimum value between
+                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                    The default is nil which means that the limit is undefined.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "ephemeral represents a volume that is
-                                handled by a cluster storage driver. The volume's
-                                lifecycle is tied to the pod that defines it - it
-                                will be created before the pod starts, and deleted
-                                when the pod is removed. \n Use this if: a) the volume
-                                is only needed while the pod runs, b) features of
-                                normal volumes like restoring from snapshot or capacity
-                                tracking are needed, c) the storage driver is specified
-                                through a storage class, and d) the storage driver
-                                supports dynamic volume provisioning through a PersistentVolumeClaim
-                                (see EphemeralVolumeSource for more information on
-                                the connection between this volume type and PersistentVolumeClaim).
-                                \n Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the
-                                lifecycle of an individual pod. \n Use CSI for light-weight
-                                local ephemeral volumes if the CSI driver is meant
-                                to be used that way - see the documentation of the
-                                driver for more information. \n A pod can use both
-                                types of ephemeral volumes and persistent volumes
-                                at the same time."
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver.
+                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                and deleted when the pod is removed.
+
+
+                                Use this if:
+                                a) the volume is only needed while the pod runs,
+                                b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and
+                                d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+
+                                Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the lifecycle
+                                of an individual pod.
+
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                be used that way - see the documentation of the driver for
+                                more information.
+
+
+                                A pod can use both types of ephemeral volumes and
+                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: "Will be used to create a stand-alone
-                                    PVC to provision the volume. The pod in which
-                                    this EphemeralVolumeSource is embedded will be
-                                    the owner of the PVC, i.e. the PVC will be deleted
-                                    together with the pod.  The name of the PVC will
-                                    be `<pod name>-<volume name>` where `<volume name>`
-                                    is the name from the `PodSpec.Volumes` array entry.
-                                    Pod validation will reject the pod if the concatenated
-                                    name is not valid for a PVC (for example, too
-                                    long). \n An existing PVC with that name that
-                                    is not owned by the pod will *not* be used for
-                                    the pod to avoid using an unrelated volume by
-                                    mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created
-                                    PVC is meant to be used by the pod, the PVC has
-                                    to updated with an owner reference to the pod
-                                    once the pod exists. Normally this should not
-                                    be necessary, but it may be useful when manually
-                                    reconstructing a broken cluster. \n This field
-                                    is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created. \n Required,
-                                    must not be nil."
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume.
+                                    The pod in which this EphemeralVolumeSource is embedded will be the
+                                    owner of the PVC, i.e. the PVC will be deleted together with the
+                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                    `<volume name>` is the name from the `PodSpec.Volumes` array
+                                    entry. Pod validation will reject the pod if the concatenated name
+                                    is not valid for a PVC (for example, too long).
+
+
+                                    An existing PVC with that name that is not owned by the pod
+                                    will *not* be used for the pod to avoid using an unrelated
+                                    volume by mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created PVC is
+                                    meant to be used by the pod, the PVC has to updated with an
+                                    owner reference to the pod once the pod exists. Normally
+                                    this should not be necessary, but it may be useful when
+                                    manually reconstructing a broken cluster.
+
+
+                                    This field is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created.
+
+
+                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: May contain labels and annotations
-                                        that will be copied into the PVC when creating
-                                        it. No other fields are allowed and will be
-                                        rejected during validation.
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it. No other fields are allowed and will be rejected during
+                                        validation.
                                       type: object
                                     spec:
-                                      description: The specification for the PersistentVolumeClaim.
-                                        The entire content is copied unchanged into
-                                        the PVC that gets created from this template.
-                                        The same fields as in a PersistentVolumeClaim
+                                      description: |-
+                                        The specification for the PersistentVolumeClaim. The entire content is
+                                        copied unchanged into the PVC that gets created from this
+                                        template. The same fields as in a PersistentVolumeClaim
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'accessModes contains the desired
-                                            access modes the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'dataSource field can be used
-                                            to specify either: * An existing VolumeSnapshot
-                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller
-                                            can support the specified data source,
-                                            it will create a new volume based on the
-                                            contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate
-                                            is enabled, dataSource contents will be
-                                            copied to dataSourceRef, and dataSourceRef
-                                            contents will be copied to dataSource
-                                            when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef
-                                            will not be copied to dataSource.'
+                                            If the provisioner or an external controller can support the specified data source,
+                                            it will create a new volume based on the contents of the specified data source.
+                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -3362,50 +3198,36 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: 'dataSourceRef specifies the
-                                            object from which to populate the volume
-                                            with data, if a non-empty volume is desired.
-                                            This may be any object from a non-empty
-                                            API group (non core object) or a PersistentVolumeClaim
-                                            object. When this field is specified,
-                                            volume binding will only succeed if the
-                                            type of the specified object matches some
-                                            installed volume populator or dynamic
-                                            provisioner. This field will replace the
-                                            functionality of the dataSource field
-                                            and as such if both fields are non-empty,
-                                            they must have the same value. For backwards
-                                            compatibility, when namespace isn''t specified
-                                            in dataSourceRef, both fields (dataSource
-                                            and dataSourceRef) will be set to the
-                                            same value automatically if one of them
-                                            is empty and the other is non-empty. When
-                                            namespace is specified in dataSourceRef,
-                                            dataSource isn''t set to the same value
-                                            and must be empty. There are three important
-                                            differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific
-                                            types of objects, dataSourceRef allows
-                                            any non-core object, as well as PersistentVolumeClaim
-                                            objects. * While dataSource ignores disallowed
-                                            values (dropping them), dataSourceRef
-                                            preserves all values, and generates an
-                                            error if a disallowed value is specified.
-                                            * While dataSource only allows local objects,
-                                            dataSourceRef allows objects in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource
-                                            feature gate to be enabled. (Alpha) Using
-                                            the namespace field of dataSourceRef requires
-                                            the CrossNamespaceVolumeDataSource feature
-                                            gate to be enabled.'
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired. This may be any object from a non-empty API group (non
+                                            core object) or a PersistentVolumeClaim object.
+                                            When this field is specified, volume binding will only succeed if the type of
+                                            the specified object matches some installed volume populator or dynamic
+                                            provisioner.
+                                            This field will replace the functionality of the dataSource field and as such
+                                            if both fields are non-empty, they must have the same value. For backwards
+                                            compatibility, when namespace isn't specified in dataSourceRef,
+                                            both fields (dataSource and dataSourceRef) will be set to the same
+                                            value automatically if one of them is empty and the other is non-empty.
+                                            When namespace is specified in dataSourceRef,
+                                            dataSource isn't set to the same value and must be empty.
+                                            There are three important differences between dataSource and dataSourceRef:
+                                            * While dataSource only allows two specific types of objects, dataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            * While dataSource only allows local objects, dataSourceRef allows objects
+                                              in any namespaces.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -3416,50 +3238,43 @@ spec:
                                                 being referenced
                                               type: string
                                             namespace:
-                                              description: Namespace is the namespace
-                                                of resource being referenced Note
-                                                that when a namespace is specified,
-                                                a gateway.networking.k8s.io/ReferenceGrant
-                                                object is required in the referent
-                                                namespace to allow that namespace's
-                                                owner to accept the reference. See
-                                                the ReferenceGrant documentation for
-                                                details. (Alpha) This field requires
-                                                the CrossNamespaceVolumeDataSource
-                                                feature gate to be enabled.
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: 'resources represents the minimum
-                                            resources the volume should have. If RecoverVolumeExpansionFailure
-                                            feature is enabled users are allowed to
-                                            specify resource requirements that are
-                                            lower than previous value but must still
-                                            be higher than capacity recorded in the
-                                            status field of the claim. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: |-
+                                            resources represents the minimum resources the volume should have.
+                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            that are lower than previous value but must still be higher than capacity recorded in the
+                                            status field of the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             claims:
-                                              description: "Claims lists the names
-                                                of resources, defined in spec.resourceClaims,
-                                                that are used by this container. \n
-                                                This is an alpha field and requires
-                                                enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable.
-                                                It can only be set for containers."
+                                              description: |-
+                                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                                that are used by this container.
+
+
+                                                This is an alpha field and requires enabling the
+                                                DynamicResourceAllocation feature gate.
+
+
+                                                This field is immutable. It can only be set for containers.
                                               items:
                                                 description: ResourceClaim references
                                                   one entry in PodSpec.ResourceClaims.
                                                 properties:
                                                   name:
-                                                    description: Name must match the
-                                                      name of one entry in pod.spec.resourceClaims
-                                                      of the Pod where this field
-                                                      is used. It makes that resource
-                                                      available inside a container.
+                                                    description: |-
+                                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                                      the Pod where this field is used. It makes that resource available
+                                                      inside a container.
                                                     type: string
                                                 required:
                                                 - name
@@ -3475,9 +3290,9 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Limits describes the maximum
-                                                amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -3486,14 +3301,11 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Requests describes the
-                                                minimum amount of compute resources
-                                                required. If Requests is omitted for
-                                                a container, it defaults to Limits
-                                                if that is explicitly specified, otherwise
-                                                to an implementation-defined value.
-                                                Requests cannot exceed Limits. More
-                                                info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Requests describes the minimum amount of compute resources required.
+                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
@@ -3505,10 +3317,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -3516,20 +3327,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3541,27 +3348,22 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: 'storageClassName is the name
-                                            of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeMode:
-                                          description: volumeMode defines what type
-                                            of volume is required by the claim. Value
-                                            of Filesystem is implied when not included
-                                            in claim spec.
+                                          description: |-
+                                            volumeMode defines what type of volume is required by the claim.
+                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
                                           description: volumeName is the binding reference
@@ -3578,21 +3380,20 @@ spec:
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. TODO: how
-                                    do we prevent errors in the filesystem from compromising
-                                    the machine'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
                                   description: 'targetWWNs is Optional: FC target
@@ -3601,28 +3402,27 @@ spec:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'wwids Optional: FC volume world wide
-                                    identifiers (wwids) Either wwids or combination
-                                    of targetWWNs and lun must be set, but not both
-                                    simultaneously.'
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: flexVolume represents a generic volume
-                                resource that is provisioned/attached using an exec
-                                based plugin.
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
                                   description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". The
-                                    default filesystem depends on FlexVolume script.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
@@ -3631,23 +3431,23 @@ spec:
                                     extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'readOnly is Optional: defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is Optional: secretRef is
-                                    reference to the secret object containing sensitive
-                                    information to pass to the plugin scripts. This
-                                    may be empty if no secret object is specified.
-                                    If the secret object contains more than one secret,
-                                    all secrets are passed to the plugin scripts.'
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugin scripts. This may be
+                                    empty if no secret object is specified. If the secret object
+                                    contains more than one secret, all secrets are passed to the plugin
+                                    scripts.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3660,9 +3460,9 @@ spec:
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: datasetName is Name of the dataset
-                                    stored as metadata -> name on the dataset for
-                                    Flocker should be considered as deprecated
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -3670,57 +3470,55 @@ spec:
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'gcePersistentDisk represents a GCE Disk
-                                resource that is attached to a kubelet''s host machine
-                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: 'fsType is filesystem type of the volume
-                                    that you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'pdName is unique name of the PD resource
-                                    in GCE. Used to identify the disk in GCE. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'gitRepo represents a git repository at
-                                a particular revision. DEPRECATED: GitRepo is deprecated.
-                                To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo
-                                using git, then mount the EmptyDir into the Pod''s
-                                container.'
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is
-                                    supplied, the volume directory will be the git
-                                    repository.  Otherwise, if specified, the volume
-                                    will contain the git repository in the subdirectory
-                                    with the given name.
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                    the subdirectory with the given name.
                                   type: string
                                 repository:
                                   description: repository is the URL
@@ -3733,54 +3531,61 @@ spec:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'glusterfs represents a Glusterfs mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: 'endpoints is the endpoint name that
-                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: 'path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the Glusterfs
-                                    volume to be mounted with read-only permissions.
-                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'hostPath represents a pre-existing file
-                                or directory on the host machine that is directly
-                                exposed to the container. This is generally used for
-                                system agents or other privileged things that are
-                                allowed to see the host machine. Most containers will
-                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                --- TODO(jonesdl) We need to restrict who can use
-                                host directory mounts and who can/can not mount host
-                                directories as read/write.'
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container. This is generally
+                                used for system agents or other privileged things that are allowed
+                                to see the host machine. Most containers will NOT need this.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                ---
+                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: 'path of the directory on the host.
-                                    If the path is a symlink, it will follow the link
-                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: 'type for HostPath Volume Defaults
-                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'iscsi represents an ISCSI Disk resource
-                                that is attached to a kubelet''s host machine and
-                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -3791,62 +3596,59 @@ spec:
                                     iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: initiatorName is the custom iSCSI Initiator
-                                    Name. If initiatorName is specified with iscsiInterface
-                                    simultaneously, new iSCSI interface <target portal>:<volume
-                                    name> will be created for the connection.
+                                  description: |-
+                                    initiatorName is the custom iSCSI Initiator Name.
+                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
                                   description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iscsiInterface is the interface Name
-                                    that uses an iSCSI transport. Defaults to 'default'
-                                    (tcp).
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: portals is the iSCSI Target Portal
-                                    List. The portal is either an IP or ip_addr:port
-                                    if the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false.
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
                                   type: boolean
                                 secretRef:
                                   description: secretRef is the CHAP Secret for iSCSI
                                     target and initiator authentication
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: targetPortal is iSCSI Target Portal.
-                                    The Portal is either an IP or ip_addr:port if
-                                    the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -3854,43 +3656,51 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'name of the volume. Must be a DNS_LABEL
-                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             nfs:
-                              description: 'nfs represents an NFS mount on the host
-                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: 'path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the NFS export
-                                    to be mounted with read-only permissions. Defaults
-                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: 'server is the hostname or IP address
-                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'persistentVolumeClaimVolumeSource represents
-                                a reference to a PersistentVolumeClaim in the same
-                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: 'claimName is the name of a PersistentVolumeClaim
-                                    in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: readOnly Will force the ReadOnly setting
-                                    in VolumeMounts. Default false.
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
                                   type: boolean
                               required:
                               - claimName
@@ -3901,10 +3711,10 @@ spec:
                                 machine
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
                                   description: pdID is the ID that identifies Photon
@@ -3918,15 +3728,15 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fSType represents the filesystem type
-                                    to mount Must be a filesystem type supported by
-                                    the host operating system. Ex. "ext4", "xfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
                                   description: volumeID uniquely identifies a Portworx
@@ -3940,16 +3750,13 @@ spec:
                                 secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: defaultMode are the mode bits used
-                                    to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Directories within the path
-                                    are not affected by this setting. This might be
-                                    in conflict with other options that affect the
-                                    file mode, like fsGroup, and the result can be
-                                    other mode bits set.
+                                  description: |-
+                                    defaultMode are the mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
@@ -3963,19 +3770,14 @@ spec:
                                           configMap data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced ConfigMap will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the ConfigMap, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the ConfigMap,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -3984,29 +3786,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -4014,10 +3808,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional specify whether
@@ -4058,20 +3852,13 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file, must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -4084,12 +3871,9 @@ spec:
                                                     start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: 'Selects a resource
-                                                    of the container: only resources
-                                                    limits and requests (limits.cpu,
-                                                    limits.memory, requests.cpu and
-                                                    requests.memory) are currently
-                                                    supported.'
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
                                                       description: 'Container name:
@@ -4123,19 +3907,14 @@ spec:
                                           secret data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced Secret will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the Secret, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the Secret,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -4144,29 +3923,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -4174,10 +3945,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional field specify whether
@@ -4190,32 +3961,26 @@ spec:
                                           about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: audience is the intended
-                                              audience of the token. A recipient of
-                                              a token must identify itself with an
-                                              identifier specified in the audience
-                                              of the token, and otherwise should reject
-                                              the token. The audience defaults to
-                                              the identifier of the apiserver.
+                                            description: |-
+                                              audience is the intended audience of the token. A recipient of a token
+                                              must identify itself with an identifier specified in the audience of the
+                                              token, and otherwise should reject the token. The audience defaults to the
+                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: expirationSeconds is the
-                                              requested duration of validity of the
-                                              service account token. As the token
-                                              approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service
-                                              account token. The kubelet will start
-                                              trying to rotate the token if the token
-                                              is older than 80 percent of its time
-                                              to live or if the token is older than
-                                              24 hours.Defaults to 1 hour and must
-                                              be at least 10 minutes.
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token. As the token approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service account token. The kubelet will
+                                              start trying to rotate the token if the token is older than 80 percent of
+                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: path is the path relative
-                                              to the mount point of the file to project
-                                              the token into.
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -4228,29 +3993,30 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: group to map volume access to Default
-                                    is no group
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: readOnly here will force the Quobyte
-                                    volume to be mounted with read-only permissions.
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: registry represents a single or multiple
-                                    Quobyte Registry services specified as a string
-                                    as host:port pair (multiple entries are separated
-                                    with commas) which acts as the central registry
-                                    for volumes
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple entries are separated with commas)
+                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: tenant owning the given Quobyte volume
-                                    in the Backend Used with dynamically provisioned
-                                    Quobyte volumes, value is set by the plugin
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: user to map volume access to Defaults
-                                    to serivceaccount user
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
                                   description: volume is a string that references
@@ -4261,60 +4027,68 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'rbd represents a Rados Block Device mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md'
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: 'image is the rados image name. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: 'keyring is the path to key ring for
-                                    RBDUser. Default is /etc/ceph/keyring. More info:
-                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: 'monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'pool is the rados pool name. Default
-                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is name of the authentication
-                                    secret for RBDUser. If provided overrides keyring.
-                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is the rados user name. Default
-                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
@@ -4325,10 +4099,11 @@ spec:
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
-                                    is "xfs".
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs".
+                                    Default is "xfs".
                                   type: string
                                 gateway:
                                   description: gateway is the host address of the
@@ -4339,21 +4114,20 @@ spec:
                                     ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef references to the secret
-                                    for ScaleIO user and other sensitive information.
-                                    If this is not provided, Login operation will
-                                    fail.
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -4362,8 +4136,8 @@ spec:
                                     communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: storageMode indicates whether the storage
-                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                  description: |-
+                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
@@ -4375,9 +4149,9 @@ spec:
                                     as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the name of a volume
-                                    already created in the ScaleIO system that is
-                                    associated with this volume source.
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -4385,34 +4159,30 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'secret represents a secret that should
-                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items If unspecified, each key-value
-                                    pair in the Data field of the referenced Secret
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -4421,25 +4191,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -4451,8 +4217,9 @@ spec:
                                     Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'secretName is the name of the secret
-                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
@@ -4460,44 +4227,42 @@ spec:
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef specifies the secret to use
-                                    for obtaining the StorageOS API credentials.  If
-                                    not specified, default values will be attempted.
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: volumeName is the human-readable name
-                                    of the StorageOS volume.  Volume names are only
-                                    unique within a namespace.
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: volumeNamespace specifies the scope
-                                    of the volume within StorageOS.  If no namespace
-                                    is specified then the Pod's namespace will be
-                                    used.  This allows the Kubernetes name scoping
-                                    to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default
-                                    behaviour. Set to "default" if you are not using
-                                    namespaces within StorageOS. Namespaces that do
-                                    not pre-exist within StorageOS will be created.
+                                  description: |-
+                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                    namespace is specified then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default behaviour.
+                                    Set to "default" if you are not using namespaces within StorageOS.
+                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
@@ -4505,10 +4270,10 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
                                   description: storagePolicyID is the storage Policy
@@ -4534,16 +4299,17 @@ spec:
                 type: object
               runnerTerminationGracePeriodSeconds:
                 default: 30
-                description: Configure the termination grace period for the runner
-                  pod. Use this parameter to allow the Terraform process to gracefully
-                  shutdown. Consider increasing for large, complex or slow-moving
-                  Terraform managed resources.
+                description: |-
+                  Configure the termination grace period for the runner pod. Use this parameter
+                  to allow the Terraform process to gracefully shutdown. Consider increasing for
+                  large, complex or slow-moving Terraform managed resources.
                 format: int64
                 type: integer
               serviceAccountName:
                 default: tf-runner
-                description: Name of a ServiceAccount for the runner Pod to provision
-                  Terraform resources. Default to tf-runner.
+                description: |-
+                  Name of a ServiceAccount for the runner Pod to provision Terraform resources.
+                  Default to tf-runner.
                 type: string
               sourceRef:
                 description: SourceRef is the reference of the source where the Terraform
@@ -4580,9 +4346,9 @@ spec:
                 - human
                 type: string
               suspend:
-                description: Suspend is to tell the controller to suspend subsequent
-                  TF executions, it does not apply to already started executions.
-                  Defaults to false.
+                description: |-
+                  Suspend is to tell the controller to suspend subsequent TF executions,
+                  it does not apply to already started executions. Defaults to false.
                 type: boolean
               targets:
                 description: Targets specify the resource, module or collection of
@@ -4595,34 +4361,46 @@ spec:
                 properties:
                   forceUnlock:
                     default: "no"
-                    description: "ForceUnlock a Terraform state if it has become locked
-                      for any reason. Defaults to `no`. \n This is an Enum and has
-                      the expected values of: \n - auto - yes - no \n WARNING: Only
-                      use `auto` in the cases where you are absolutely certain that
-                      no other system is using this state, you could otherwise end
-                      up in a bad place See https://www.terraform.io/language/state/locking#force-unlock
-                      for more information on the terraform state lock and force unlock."
+                    description: |-
+                      ForceUnlock a Terraform state if it has become locked for any reason. Defaults to `no`.
+
+
+                      This is an Enum and has the expected values of:
+
+
+                      - auto
+                      - yes
+                      - no
+
+
+                      WARNING: Only use `auto` in the cases where you are absolutely certain that
+                      no other system is using this state, you could otherwise end up in a bad place
+                      See https://www.terraform.io/language/state/locking#force-unlock for more
+                      information on the terraform state lock and force unlock.
                     enum:
                     - "yes"
                     - "no"
                     - auto
                     type: string
                   lockIdentifier:
-                    description: "LockIdentifier holds the Identifier required by
-                      Terraform to unlock the state if it ever gets into a locked
-                      state. \n You'll need to put the Lock Identifier in here while
-                      setting ForceUnlock to either `yes` or `auto`. \n Leave this
-                      empty to do nothing, set this to the value of the `Lock Info:
-                      ID: [value]`, e.g. `f2ab685b-f84d-ac0b-a125-378a22877e8d`, to
-                      force unlock the state."
+                    description: |-
+                      LockIdentifier holds the Identifier required by Terraform to unlock the state
+                      if it ever gets into a locked state.
+
+
+                      You'll need to put the Lock Identifier in here while setting ForceUnlock to
+                      either `yes` or `auto`.
+
+
+                      Leave this empty to do nothing, set this to the value of the `Lock Info: ID: [value]`,
+                      e.g. `f2ab685b-f84d-ac0b-a125-378a22877e8d`, to force unlock the state.
                     type: string
                 type: object
               values:
-                description: Values map to the Terraform variable "values", which
-                  is an object of arbitrary values. It is a convenient way to pass
-                  values to Terraform resources without having to define a variable
-                  for each value. To use this feature, your Terraform file must define
-                  the variable "values".
+                description: |-
+                  Values map to the Terraform variable "values", which is an object of arbitrary values.
+                  It is a convenient way to pass values to Terraform resources without having to define
+                  a variable for each value. To use this feature, your Terraform file must define the variable "values".
                 x-kubernetes-preserve-unknown-fields: true
               vars:
                 description: List of input variables to set for the Terraform program.
@@ -4644,8 +4422,10 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -4656,10 +4436,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
-                          description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
                               description: Version of the schema the FieldPath is
@@ -4674,10 +4453,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
-                          description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
                               description: 'Container name: required for volumes,
@@ -4706,8 +4484,10 @@ spec:
                                 be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must
@@ -4723,14 +4503,14 @@ spec:
                   type: object
                 type: array
               varsFrom:
-                description: List of references to a Secret or a ConfigMap to generate
-                  variables for Terraform resources based on its data, selectively
-                  by varsKey. Values of the later Secret / ConfigMap with the same
-                  keys will override those of the former.
+                description: |-
+                  List of references to a Secret or a ConfigMap to generate variables for
+                  Terraform resources based on its data, selectively by varsKey. Values of the later
+                  Secret / ConfigMap with the same keys will override those of the former.
                 items:
-                  description: VarsReference contain a reference of a Secret or a
-                    ConfigMap to generate variables for Terraform resources based
-                    on its data, selectively by varsKey.
+                  description: |-
+                    VarsReference contain a reference of a Secret or a ConfigMap to generate
+                    variables for Terraform resources based on its data, selectively by varsKey.
                   properties:
                     kind:
                       description: Kind of the values referent, valid values are ('Secret',
@@ -4740,16 +4520,17 @@ spec:
                       - ConfigMap
                       type: string
                     name:
-                      description: Name of the values referent. Should reside in the
-                        same namespace as the referring resource.
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
                       maxLength: 253
                       minLength: 1
                       type: string
                     optional:
-                      description: Optional marks this VarsReference as optional.
-                        When set, a not found error for the values reference is ignored,
-                        but any VarsKey or transient error will still result in a
-                        reconciliation failure.
+                      description: |-
+                        Optional marks this VarsReference as optional. When set, a not found error
+                        for the values reference is ignored, but any VarsKey or
+                        transient error will still result in a reconciliation failure.
                       type: boolean
                     varsKeys:
                       description: VarsKeys is the data key at which a specific value
@@ -4798,9 +4579,9 @@ spec:
                     description: Name is the name of the Secret to be written
                     type: string
                   outputs:
-                    description: Outputs contain the selected names of outputs to
-                      be written to the secret. Empty array means writing all outputs,
-                      which is default.
+                    description: |-
+                      Outputs contain the selected names of outputs to be written
+                      to the secret. Empty array means writing all outputs, which is default.
                     items:
                       type: string
                     type: array
@@ -4821,42 +4602,42 @@ spec:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -4870,11 +4651,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -4916,13 +4698,15 @@ spec:
                 - entries
                 type: object
               lastAppliedByDriftDetectionAt:
-                description: LastAppliedByDriftDetectionAt is the time when the last
-                  drift was detected and terraform apply was performed as a result
+                description: |-
+                  LastAppliedByDriftDetectionAt is the time when the last drift was detected and
+                  terraform apply was performed as a result
                 format: date-time
                 type: string
               lastAppliedRevision:
-                description: The last successfully applied revision. The revision
-                  format for Git sources is <branch|tag>/<commit-sha>.
+                description: |-
+                  The last successfully applied revision.
+                  The revision format for Git sources is <branch|tag>/<commit-sha>.
                 type: string
               lastAttemptedRevision:
                 description: LastAttemptedRevision is the revision of the last reconciliation
@@ -4934,14 +4718,15 @@ spec:
                 format: date-time
                 type: string
               lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value can
-                  be detected.
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
                 type: string
               lastPlannedRevision:
-                description: LastPlannedRevision is the revision used by the last
-                  planning process. The result could be either no plan change or a
-                  new plan generated.
+                description: |-
+                  LastPlannedRevision is the revision used by the last planning process.
+                  The result could be either no plan change or a new plan generated.
                 type: string
               lock:
                 description: LockStatus defines the observed state of a Terraform
@@ -4991,14 +4776,19 @@ spec:
         description: Terraform is the Schema for the terraforms API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -5010,9 +4800,9 @@ spec:
                 description: Clean the runner pod up after each reconciliation cycle
                 type: boolean
               approvePlan:
-                description: ApprovePlan specifies name of a plan wanted to approve.
-                  If its value is "auto", the controller will automatically approve
-                  every plan.
+                description: |-
+                  ApprovePlan specifies name of a plan wanted to approve.
+                  If its value is "auto", the controller will automatically approve every plan.
                 type: string
               backendConfig:
                 description: BackendConfigSpec is for specifying configuration for
@@ -5051,16 +4841,17 @@ spec:
                       - ConfigMap
                       type: string
                     name:
-                      description: Name of the configs referent. Should reside in
-                        the same namespace as the referring resource.
+                      description: |-
+                        Name of the configs referent. Should reside in the same namespace as the
+                        referring resource.
                       maxLength: 253
                       minLength: 1
                       type: string
                     optional:
-                      description: Optional marks this BackendConfigsReference as
-                        optional. When set, a not found error for the values reference
-                        is ignored, but any Key or transient error will still result
-                        in a reconciliation failure.
+                      description: |-
+                        Optional marks this BackendConfigsReference as optional. When set, a not found error
+                        for the values reference is ignored, but any Key or
+                        transient error will still result in a reconciliation failure.
                       type: boolean
                   required:
                   - kind
@@ -5071,19 +4862,21 @@ spec:
                 description: BranchPlanner configuration.
                 properties:
                   enablePathScope:
-                    description: EnablePathScope specifies if the Branch Planner should
-                      or shouldn't check if a Pull Request has changes under `.spec.path`.
-                      If enabled extra resources will be created only if there are
-                      any changes in terraform files.
+                    description: |-
+                      EnablePathScope specifies if the Branch Planner should or shouldn't check
+                      if a Pull Request has changes under `.spec.path`. If enabled extra
+                      resources will be created only if there are any changes in terraform files.
                     type: boolean
                 type: object
               breakTheGlass:
-                description: BreakTheGlass specifies if the reconciliation should
-                  stop and allow interactive shell in case of emergency.
+                description: |-
+                  BreakTheGlass specifies if the reconciliation should stop
+                  and allow interactive shell in case of emergency.
                 type: boolean
               cliConfigSecretRef:
-                description: SecretReference represents a Secret Reference. It has
-                  enough information to retrieve secret in any namespace
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
                 properties:
                   name:
                     description: name is unique within a namespace to reference a
@@ -5118,8 +4911,9 @@ spec:
                 type: object
               dependsOn:
                 items:
-                  description: NamespacedObjectReference contains enough information
-                    to locate the referenced Kubernetes resource object in any namespace.
+                  description: |-
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
                   properties:
                     name:
                       description: Name of the referent.
@@ -5138,14 +4932,15 @@ spec:
                 type: boolean
               destroyResourcesOnDeletion:
                 default: false
-                description: Create destroy plan and apply it to destroy terraform
-                  resources upon deletion of this object. Defaults to false.
+                description: |-
+                  Create destroy plan and apply it to destroy terraform resources
+                  upon deletion of this object. Defaults to false.
                 type: boolean
               disableDriftDetection:
                 default: false
-                description: Disable automatic drift detection. Drift detection may
-                  be resource intensive in the context of a large cluster or complex
-                  Terraform statefile. Defaults to false.
+                description: |-
+                  Disable automatic drift detection. Drift detection may be resource intensive in
+                  the context of a large cluster or complex Terraform statefile. Defaults to false.
                 type: boolean
               enableInventory:
                 description: EnableInventory enables the object to store resource
@@ -5154,6 +4949,15 @@ spec:
               enterprise:
                 description: Enterprise is the enterprise configuration placeholder.
                 x-kubernetes-preserve-unknown-fields: true
+              execType:
+                default: terraform
+                description: |-
+                  ExecType specifies the type of executable used for the operations.
+                  It can be either 'terraform', which is the default, or 'tofu'.
+                enum:
+                - terraform
+                - tofu
+                type: string
               fileMappings:
                 description: List of all configuration files to be created in initialization.
                 items:
@@ -5190,19 +4994,22 @@ spec:
                 type: array
               force:
                 default: false
-                description: Force instructs the controller to unconditionally re-plan
-                  and re-apply TF resources. Defaults to false.
+                description: |-
+                  Force instructs the controller to unconditionally
+                  re-plan and re-apply TF resources. Defaults to false.
                 type: boolean
               healthChecks:
                 description: List of health checks to be performed.
                 items:
-                  description: HealthCheck contains configuration needed to perform
-                    a health check after terraform is applied.
+                  description: |-
+                    HealthCheck contains configuration needed to perform a health check after
+                    terraform is applied.
                   properties:
                     address:
-                      description: Address to perform tcp health check on. Required
-                        when tcp type is specified. Go template can be used to reference
-                        values from the terraform output (e.g. 127.0.0.1:8080).
+                      description: |-
+                        Address to perform tcp health check on. Required when tcp type is specified.
+                        Go template can be used to reference values from the terraform output
+                        (e.g. 127.0.0.1:8080, {{.address}}:{{.port}}).
                       type: string
                     name:
                       description: Name of the health check.
@@ -5211,22 +5018,25 @@ spec:
                       type: string
                     timeout:
                       default: 20s
-                      description: The timeout period at which the connection should
-                        timeout if unable to complete the request. When not specified,
-                        default 20s timeout is used.
+                      description: |-
+                        The timeout period at which the connection should timeout if unable to
+                        complete the request.
+                        When not specified, default 20s timeout is used.
                       type: string
                     type:
-                      description: Type of the health check, valid values are ('tcp',
-                        'http'). If tcp is specified, address is required. If http
-                        is specified, url is required.
+                      description: |-
+                        Type of the health check, valid values are ('tcp', 'http').
+                        If tcp is specified, address is required.
+                        If http is specified, url is required.
                       enum:
                       - tcp
                       - http
                       type: string
                     url:
-                      description: URL to perform http health check on. Required when
-                        http type is specified. Go template can be used to reference
-                        values from the terraform output (e.g. https://example.org).
+                      description: |-
+                        URL to perform http health check on. Required when http type is specified.
+                        Go template can be used to reference values from the terraform output
+                        (e.g. https://example.org, {{.output_url}}).
                       type: string
                   required:
                   - name
@@ -5243,12 +5053,14 @@ spec:
                 format: int32
                 type: integer
               path:
-                description: Path to the directory containing Terraform (.tf) files.
+                description: |-
+                  Path to the directory containing Terraform (.tf) files.
                   Defaults to 'None', which translates to the root path of the SourceRef.
                 type: string
               planOnly:
-                description: PlanOnly specifies if the reconciliation should or should
-                  not stop at plan phase.
+                description: |-
+                  PlanOnly specifies if the reconciliation should or should not stop at plan
+                  phase.
                 type: boolean
               readInputsFromSecrets:
                 items:
@@ -5268,18 +5080,21 @@ spec:
                   the apply step.
                 type: boolean
               remediation:
-                description: Remediation specifies what the controller should do when
-                  reconciliation fails. The default is to not perform any action.
+                description: |-
+                  Remediation specifies what the controller should do when reconciliation
+                  fails. The default is to not perform any action.
                 properties:
                   retries:
-                    description: Retries is the number of retries that should be attempted
-                      on failures before bailing. Defaults to '0', a negative integer
-                      denotes unlimited retries.
+                    description: |-
+                      Retries is the number of retries that should be attempted on failures
+                      before bailing. Defaults to '0', a negative integer denotes unlimited
+                      retries.
                     format: int64
                     type: integer
                 type: object
               retryInterval:
-                description: The interval at which to retry a previously failed reconciliation.
+                description: |-
+                  The interval at which to retry a previously failed reconciliation.
                   The default value is 15 when not specified.
                 type: string
               runnerPodTemplate:
@@ -5307,23 +5122,20 @@ spec:
                               for the pod.
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node matches the corresponding matchExpressions;
-                                  the node(s) with the highest sum are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
-                                  description: An empty preferred scheduling term
-                                    matches all objects with implicit weight 0 (i.e.
-                                    it's a no-op). A null preferred scheduling term
-                                    matches no objects (i.e. is also a no-op).
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
                                     preference:
                                       description: A node selector term, associated
@@ -5333,32 +5145,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5371,32 +5177,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5419,53 +5219,46 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to an update), the system may or may not try
-                                  to eventually evict the pod from its node.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
                                       terms. The terms are ORed.
                                     items:
-                                      description: A null or empty node selector term
-                                        matches no objects. The requirements of them
-                                        are ANDed. The TopologySelectorTerm type implements
-                                        a subset of the NodeSelectorTerm.
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                       properties:
                                         matchExpressions:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5478,32 +5271,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5526,19 +5313,16 @@ spec:
                               other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -5557,10 +5341,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -5568,20 +5351,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -5593,36 +5372,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -5630,20 +5402,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -5655,46 +5423,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -5703,25 +5462,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to a pod label update), the system may or may
-                                  not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes
-                                  corresponding to each podAffinityTerm are intersected,
-                                  i.e. all terms must be satisfied.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -5732,30 +5488,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5767,53 +5518,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5825,34 +5568,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -5866,19 +5603,16 @@ spec:
                               etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the anti-affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity
-                                  expressions, etc.), compute a sum by iterating through
-                                  the elements of this field and adding "weight" to
-                                  the sum if the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -5897,10 +5631,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -5908,20 +5641,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -5933,36 +5662,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -5970,20 +5692,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -5995,46 +5713,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -6043,25 +5752,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the anti-affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  anti-affinity requirements specified by this field
-                                  cease to be met at some point during pod execution
-                                  (e.g. due to a pod label update), the system may
-                                  or may not try to eventually evict the pod from
-                                  its node. When there are multiple elements, the
-                                  lists of nodes corresponding to each podAffinityTerm
-                                  are intersected, i.e. all terms must be satisfied.
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -6072,30 +5778,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6107,53 +5808,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6165,34 +5858,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -6202,7 +5889,8 @@ spec:
                             type: object
                         type: object
                       env:
-                        description: List of environment variables to set in the container.
+                        description: |-
+                          List of environment variables to set in the container.
                           Cannot be updated.
                         items:
                           description: EnvVar represents an environment variable present
@@ -6213,16 +5901,16 @@ spec:
                                 be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables
-                                in the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. Double $$ are
-                                reduced to a single $, which allows for escaping the
-                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Defaults to "".'
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -6235,10 +5923,10 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -6249,11 +5937,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
                                       description: Version of the schema the FieldPath
@@ -6268,11 +5954,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -6302,10 +5986,10 @@ spec:
                                         from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -6321,13 +6005,13 @@ spec:
                           type: object
                         type: array
                       envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must
-                          be a C_IDENTIFIER. All invalid keys will be reported as
-                          an event when the container is starting. When a key exists
-                          in multiple sources, the value associated with the last
-                          source will take precedence. Values defined by an Env with
-                          a duplicate key will take precedence. Cannot be updated.
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -6336,9 +6020,10 @@ spec:
                               description: The ConfigMap to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must
@@ -6354,9 +6039,10 @@ spec:
                               description: The Secret to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be
@@ -6369,9 +6055,9 @@ spec:
                       hostAliases:
                         description: Set host aliases for the Runner Pod
                         items:
-                          description: HostAlias holds the mapping between IP and
-                            hostnames that will be injected as an entry in the pod's
-                            hosts file.
+                          description: |-
+                            HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                            pod's hosts file.
                           properties:
                             hostnames:
                               description: Hostnames for the above IP address.
@@ -6393,38 +6079,35 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The container
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The container image''s ENTRYPOINT is used
-                                if this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -6434,17 +6117,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -6457,10 +6139,10 @@ spec:
                                             description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -6471,11 +6153,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                         properties:
                                           apiVersion:
                                             description: Version of the schema the
@@ -6491,11 +6171,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -6527,10 +6205,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -6546,14 +6224,13 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -6562,10 +6239,10 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -6581,10 +6258,10 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -6595,44 +6272,42 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                This field is optional to allow higher level config
-                                management to default or override container images
-                                in workload controllers like Deployments and StatefulSets.'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
-                              description: Actions that the management system should
-                                take in response to container lifecycle events. Cannot
-                                be updated.
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -6642,8 +6317,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -6654,10 +6329,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -6675,24 +6349,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -6702,44 +6376,37 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -6749,8 +6416,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -6761,10 +6428,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -6782,24 +6448,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -6809,10 +6475,10 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -6820,30 +6486,29 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness.
-                                Container will be restarted if the probe fails. Cannot
-                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -6857,11 +6522,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -6871,9 +6537,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -6883,10 +6549,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -6903,34 +6568,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -6945,61 +6611,59 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL.
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
                                 Each container in a pod must have a unique name (DNS_LABEL).
                                 Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container.
-                                Not specifying a port here DOES NOT prevent that port
-                                from being exposed. Any port which is listening on
-                                the default "0.0.0.0" address inside a container will
-                                be accessible from the network. Modifying this array
-                                with strategic merge patch may corrupt the data. For
-                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                 Cannot be updated.
                               items:
                                 description: ContainerPort represents a network port
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -7007,23 +6671,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -7034,30 +6699,29 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness.
-                                Container will be removed from service endpoints if
-                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -7071,11 +6735,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -7085,9 +6750,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -7097,10 +6762,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -7117,34 +6781,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -7159,36 +6824,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -7199,14 +6861,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -7215,25 +6877,31 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -7249,8 +6917,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -7259,35 +6928,34 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             securityContext:
-                              description: 'SecurityContext defines the security options
-                                the container should be run with. If set, the fields
-                                of SecurityContext override the equivalent fields
-                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -7305,66 +6973,60 @@ spec:
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -7384,107 +7046,95 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must only be set if type is "Localhost".
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must only be set if type is "Localhost".
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        This field is alpha-level and will only be
-                                        honored by components that enable the WindowsHostProcessContainers
-                                        feature flag. Setting this field without the
-                                        feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be honored by components that enable the
+                                        WindowsHostProcessContainers feature flag. Setting this field without the feature
+                                        flag will result in errors when validating the Pod. All of a Pod's containers must
+                                        have the same effective HostProcess value (it is not allowed to have a mix of HostProcess
+                                        containers and non-HostProcess containers).  In addition, if HostProcess is true
+                                        then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has
-                                successfully initialized. If specified, no other probes
-                                are executed until this completes successfully. If
-                                this probe fails, the Pod will be restarted, just
-                                as if the livenessProbe failed. This can be used to
-                                provide different probe parameters at the beginning
-                                of a Pod''s lifecycle, when it might take a long time
-                                to load data or warm a cache, than during steady-state
-                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -7498,11 +7148,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -7512,9 +7163,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -7524,10 +7175,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -7544,34 +7194,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -7586,83 +7237,75 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -7687,44 +7330,44 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -7732,10 +7375,11 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
@@ -7753,18 +7397,23 @@ spec:
                         description: Set Resources for the Runner Pod container
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -7781,8 +7430,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7791,30 +7441,31 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       securityContext:
                         description: Set SecurityContext for the Runner Pod container
                         properties:
                           allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether
-                              a process can gain more privileges than its parent process.
-                              This bool directly controls if the no_new_privs flag
-                              will be set on the container process. AllowPrivilegeEscalation
-                              is true always when the container is: 1) run as Privileged
-                              2) has CAP_SYS_ADMIN Note that this field cannot be
-                              set when spec.os.name is windows.'
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running
-                              containers. Defaults to the default set of capabilities
-                              granted by the container runtime. Note that this field
-                              cannot be set when spec.os.name is windows.
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
                                 description: Added capabilities
@@ -7832,61 +7483,60 @@ spec:
                                 type: array
                             type: object
                           privileged:
-                            description: Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent
-                              to root on the host. Defaults to false. Note that this
-                              field cannot be set when spec.os.name is windows.
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
-                            description: procMount denotes the type of proc mount
-                              to use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root
-                              filesystem. Default is false. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set
-                              when spec.os.name is windows.
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description: Indicates that the container must run as
-                              a non-root user. If true, the Kubelet will validate
-                              the image at runtime to ensure that it does not run
-                              as UID 0 (root) and fail to start the container if it
-                              does. If unset or false, no such validation will be
-                              performed. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                              Note that this field cannot be set when spec.os.name
-                              is windows.
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to the
-                              container. If unspecified, the container runtime will
-                              allocate a random SELinux context for each container.  May
-                              also be set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set
-                              when spec.os.name is windows.
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -7906,111 +7556,104 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by this container.
-                              If seccomp options are provided at both the pod & container
-                              level, the container options override the pod options.
-                              Note that this field cannot be set when spec.os.name
-                              is windows.
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
-                                description: localhostProfile indicates a profile
-                                  defined in a file on the node should be used. The
-                                  profile must be preconfigured on the node to work.
-                                  Must be a descending path, relative to the kubelet's
-                                  configured seccomp profile location. Must only be
-                                  set if type is "Localhost".
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must only be set if type is "Localhost".
                                 type: string
                               type:
-                                description: "type indicates which kind of seccomp
-                                  profile will be applied. Valid options are: \n Localhost
-                                  - a profile defined in a file on the node should
-                                  be used. RuntimeDefault - the container runtime
-                                  default profile should be used. Unconfined - no
-                                  profile should be applied."
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                             - type
                             type: object
                           windowsOptions:
-                            description: The Windows specific settings applied to
-                              all containers. If unspecified, the options from the
-                              PodSecurityContext will be used. If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set
-                              when spec.os.name is linux.
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA
-                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec
-                                  named by the GMSACredentialSpecName field.
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of
                                   the GMSA credential spec to use.
                                 type: string
                               hostProcess:
-                                description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container. This
-                                  field is alpha-level and will only be honored by
-                                  components that enable the WindowsHostProcessContainers
-                                  feature flag. Setting this field without the feature
-                                  flag will result in errors when validating the Pod.
-                                  All of a Pod's containers must have the same effective
-                                  HostProcess value (it is not allowed to have a mix
-                                  of HostProcess containers and non-HostProcess containers).  In
-                                  addition, if HostProcess is true then HostNetwork
-                                  must also be set to true.
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  This field is alpha-level and will only be honored by components that enable the
+                                  WindowsHostProcessContainers feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod. All of a Pod's containers must
+                                  have the same effective HostProcess value (it is not allowed to have a mix of HostProcess
+                                  containers and non-HostProcess containers).  In addition, if HostProcess is true
+                                  then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       tolerations:
                         description: Set the Tolerations for the Runner Pod
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -8021,34 +7664,36 @@ spec:
                             within a container.
                           properties:
                             mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
                               type: string
                             name:
                               description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                           - mountPath
@@ -8062,37 +7707,36 @@ spec:
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'awsElasticBlockStore represents an AWS
-                                Disk resource that is attached to a kubelet''s host
-                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly value true will force the
-                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: 'volumeID is unique ID of the persistent
-                                    disk resource in AWS (Amazon EBS volume). More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
@@ -8114,10 +7758,10 @@ spec:
                                     the blob storage
                                   type: string
                                 fsType:
-                                  description: fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
                                   description: 'kind expected values are Shared: multiple
@@ -8127,9 +7771,9 @@ spec:
                                     set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
@@ -8140,9 +7784,9 @@ spec:
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
                                   description: secretName is the  name of secret that
@@ -8160,8 +7804,9 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'monitors is Required: Monitors is
-                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
@@ -8171,67 +7816,72 @@ spec:
                                     is /'
                                   type: string
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: 'secretFile is Optional: SecretFile
-                                    is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: 'secretRef is Optional: SecretRef is
-                                    reference to the authentication secret for User,
-                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is optional: User is the rados
-                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'cinder represents a cinder volume attached
-                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Examples: "ext4", "xfs", "ntfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: 'readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is optional: points to a
-                                    secret object containing parameters used to connect
-                                    to OpenStack.'
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: 'volumeID used to identify the volume
-                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
@@ -8241,30 +7891,25 @@ spec:
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items if unspecified, each key-value
-                                    pair in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -8273,25 +7918,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -8299,9 +7940,10 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: optional specify whether the ConfigMap
@@ -8315,45 +7957,43 @@ spec:
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: driver is the name of the CSI driver
-                                    that handles this volume. Consult with your admin
-                                    for the correct name as registered in the cluster.
+                                  description: |-
+                                    driver is the name of the CSI driver that handles this volume.
+                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: fsType to mount. Ex. "ext4", "xfs",
-                                    "ntfs". If not provided, the empty value is passed
-                                    to the associated CSI driver which will determine
-                                    the default filesystem to apply.
+                                  description: |-
+                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated CSI driver
+                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: nodePublishSecretRef is a reference
-                                    to the secret object containing sensitive information
-                                    to pass to the CSI driver to complete the CSI
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no
-                                    secret is required. If the secret object contains
-                                    more than one secret, all secret references are
-                                    passed.
+                                    This field is optional, and  may be empty if no secret is required. If the
+                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: readOnly specifies a read-only configuration
-                                    for the volume. Defaults to false (read/write).
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: volumeAttributes stores driver-specific
-                                    properties that are passed to the CSI driver.
-                                    Consult your driver's documentation for supported
-                                    values.
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
@@ -8363,17 +8003,15 @@ spec:
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits to use on created
-                                    files by default. Must be a Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    Optional: mode bits to use on created files by default. Must be a
+                                    Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
@@ -8403,16 +8041,13 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file, must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
@@ -8423,10 +8058,9 @@ spec:
                                           the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -8454,121 +8088,125 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'emptyDir represents a temporary directory
-                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: 'medium represents what type of storage
-                                    medium should back this directory. The default
-                                    is "" which means to use the node''s default medium.
-                                    Must be an empty string (default) or Memory. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    medium represents what type of storage medium should back this directory.
+                                    The default is "" which means to use the node's default medium.
+                                    Must be an empty string (default) or Memory.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'sizeLimit is the total amount of local
-                                    storage required for this EmptyDir volume. The
-                                    size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would
-                                    be the minimum value between the SizeLimit specified
-                                    here and the sum of memory limits of all containers
-                                    in a pod. The default is nil which means that
-                                    the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                    The size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would be the minimum value between
+                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                    The default is nil which means that the limit is undefined.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "ephemeral represents a volume that is
-                                handled by a cluster storage driver. The volume's
-                                lifecycle is tied to the pod that defines it - it
-                                will be created before the pod starts, and deleted
-                                when the pod is removed. \n Use this if: a) the volume
-                                is only needed while the pod runs, b) features of
-                                normal volumes like restoring from snapshot or capacity
-                                tracking are needed, c) the storage driver is specified
-                                through a storage class, and d) the storage driver
-                                supports dynamic volume provisioning through a PersistentVolumeClaim
-                                (see EphemeralVolumeSource for more information on
-                                the connection between this volume type and PersistentVolumeClaim).
-                                \n Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the
-                                lifecycle of an individual pod. \n Use CSI for light-weight
-                                local ephemeral volumes if the CSI driver is meant
-                                to be used that way - see the documentation of the
-                                driver for more information. \n A pod can use both
-                                types of ephemeral volumes and persistent volumes
-                                at the same time."
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver.
+                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                and deleted when the pod is removed.
+
+
+                                Use this if:
+                                a) the volume is only needed while the pod runs,
+                                b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and
+                                d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+
+                                Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the lifecycle
+                                of an individual pod.
+
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                be used that way - see the documentation of the driver for
+                                more information.
+
+
+                                A pod can use both types of ephemeral volumes and
+                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: "Will be used to create a stand-alone
-                                    PVC to provision the volume. The pod in which
-                                    this EphemeralVolumeSource is embedded will be
-                                    the owner of the PVC, i.e. the PVC will be deleted
-                                    together with the pod.  The name of the PVC will
-                                    be `<pod name>-<volume name>` where `<volume name>`
-                                    is the name from the `PodSpec.Volumes` array entry.
-                                    Pod validation will reject the pod if the concatenated
-                                    name is not valid for a PVC (for example, too
-                                    long). \n An existing PVC with that name that
-                                    is not owned by the pod will *not* be used for
-                                    the pod to avoid using an unrelated volume by
-                                    mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created
-                                    PVC is meant to be used by the pod, the PVC has
-                                    to updated with an owner reference to the pod
-                                    once the pod exists. Normally this should not
-                                    be necessary, but it may be useful when manually
-                                    reconstructing a broken cluster. \n This field
-                                    is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created. \n Required,
-                                    must not be nil."
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume.
+                                    The pod in which this EphemeralVolumeSource is embedded will be the
+                                    owner of the PVC, i.e. the PVC will be deleted together with the
+                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                    `<volume name>` is the name from the `PodSpec.Volumes` array
+                                    entry. Pod validation will reject the pod if the concatenated name
+                                    is not valid for a PVC (for example, too long).
+
+
+                                    An existing PVC with that name that is not owned by the pod
+                                    will *not* be used for the pod to avoid using an unrelated
+                                    volume by mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created PVC is
+                                    meant to be used by the pod, the PVC has to updated with an
+                                    owner reference to the pod once the pod exists. Normally
+                                    this should not be necessary, but it may be useful when
+                                    manually reconstructing a broken cluster.
+
+
+                                    This field is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created.
+
+
+                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: May contain labels and annotations
-                                        that will be copied into the PVC when creating
-                                        it. No other fields are allowed and will be
-                                        rejected during validation.
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it. No other fields are allowed and will be rejected during
+                                        validation.
                                       type: object
                                     spec:
-                                      description: The specification for the PersistentVolumeClaim.
-                                        The entire content is copied unchanged into
-                                        the PVC that gets created from this template.
-                                        The same fields as in a PersistentVolumeClaim
+                                      description: |-
+                                        The specification for the PersistentVolumeClaim. The entire content is
+                                        copied unchanged into the PVC that gets created from this
+                                        template. The same fields as in a PersistentVolumeClaim
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'accessModes contains the desired
-                                            access modes the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'dataSource field can be used
-                                            to specify either: * An existing VolumeSnapshot
-                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller
-                                            can support the specified data source,
-                                            it will create a new volume based on the
-                                            contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate
-                                            is enabled, dataSource contents will be
-                                            copied to dataSourceRef, and dataSourceRef
-                                            contents will be copied to dataSource
-                                            when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef
-                                            will not be copied to dataSource.'
+                                            If the provisioner or an external controller can support the specified data source,
+                                            it will create a new volume based on the contents of the specified data source.
+                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -8584,50 +8222,36 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: 'dataSourceRef specifies the
-                                            object from which to populate the volume
-                                            with data, if a non-empty volume is desired.
-                                            This may be any object from a non-empty
-                                            API group (non core object) or a PersistentVolumeClaim
-                                            object. When this field is specified,
-                                            volume binding will only succeed if the
-                                            type of the specified object matches some
-                                            installed volume populator or dynamic
-                                            provisioner. This field will replace the
-                                            functionality of the dataSource field
-                                            and as such if both fields are non-empty,
-                                            they must have the same value. For backwards
-                                            compatibility, when namespace isn''t specified
-                                            in dataSourceRef, both fields (dataSource
-                                            and dataSourceRef) will be set to the
-                                            same value automatically if one of them
-                                            is empty and the other is non-empty. When
-                                            namespace is specified in dataSourceRef,
-                                            dataSource isn''t set to the same value
-                                            and must be empty. There are three important
-                                            differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific
-                                            types of objects, dataSourceRef allows
-                                            any non-core object, as well as PersistentVolumeClaim
-                                            objects. * While dataSource ignores disallowed
-                                            values (dropping them), dataSourceRef
-                                            preserves all values, and generates an
-                                            error if a disallowed value is specified.
-                                            * While dataSource only allows local objects,
-                                            dataSourceRef allows objects in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource
-                                            feature gate to be enabled. (Alpha) Using
-                                            the namespace field of dataSourceRef requires
-                                            the CrossNamespaceVolumeDataSource feature
-                                            gate to be enabled.'
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired. This may be any object from a non-empty API group (non
+                                            core object) or a PersistentVolumeClaim object.
+                                            When this field is specified, volume binding will only succeed if the type of
+                                            the specified object matches some installed volume populator or dynamic
+                                            provisioner.
+                                            This field will replace the functionality of the dataSource field and as such
+                                            if both fields are non-empty, they must have the same value. For backwards
+                                            compatibility, when namespace isn't specified in dataSourceRef,
+                                            both fields (dataSource and dataSourceRef) will be set to the same
+                                            value automatically if one of them is empty and the other is non-empty.
+                                            When namespace is specified in dataSourceRef,
+                                            dataSource isn't set to the same value and must be empty.
+                                            There are three important differences between dataSource and dataSourceRef:
+                                            * While dataSource only allows two specific types of objects, dataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            * While dataSource only allows local objects, dataSourceRef allows objects
+                                              in any namespaces.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -8638,50 +8262,43 @@ spec:
                                                 being referenced
                                               type: string
                                             namespace:
-                                              description: Namespace is the namespace
-                                                of resource being referenced Note
-                                                that when a namespace is specified,
-                                                a gateway.networking.k8s.io/ReferenceGrant
-                                                object is required in the referent
-                                                namespace to allow that namespace's
-                                                owner to accept the reference. See
-                                                the ReferenceGrant documentation for
-                                                details. (Alpha) This field requires
-                                                the CrossNamespaceVolumeDataSource
-                                                feature gate to be enabled.
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: 'resources represents the minimum
-                                            resources the volume should have. If RecoverVolumeExpansionFailure
-                                            feature is enabled users are allowed to
-                                            specify resource requirements that are
-                                            lower than previous value but must still
-                                            be higher than capacity recorded in the
-                                            status field of the claim. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: |-
+                                            resources represents the minimum resources the volume should have.
+                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            that are lower than previous value but must still be higher than capacity recorded in the
+                                            status field of the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             claims:
-                                              description: "Claims lists the names
-                                                of resources, defined in spec.resourceClaims,
-                                                that are used by this container. \n
-                                                This is an alpha field and requires
-                                                enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable.
-                                                It can only be set for containers."
+                                              description: |-
+                                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                                that are used by this container.
+
+
+                                                This is an alpha field and requires enabling the
+                                                DynamicResourceAllocation feature gate.
+
+
+                                                This field is immutable. It can only be set for containers.
                                               items:
                                                 description: ResourceClaim references
                                                   one entry in PodSpec.ResourceClaims.
                                                 properties:
                                                   name:
-                                                    description: Name must match the
-                                                      name of one entry in pod.spec.resourceClaims
-                                                      of the Pod where this field
-                                                      is used. It makes that resource
-                                                      available inside a container.
+                                                    description: |-
+                                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                                      the Pod where this field is used. It makes that resource available
+                                                      inside a container.
                                                     type: string
                                                 required:
                                                 - name
@@ -8697,9 +8314,9 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Limits describes the maximum
-                                                amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -8708,14 +8325,11 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Requests describes the
-                                                minimum amount of compute resources
-                                                required. If Requests is omitted for
-                                                a container, it defaults to Limits
-                                                if that is explicitly specified, otherwise
-                                                to an implementation-defined value.
-                                                Requests cannot exceed Limits. More
-                                                info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Requests describes the minimum amount of compute resources required.
+                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
@@ -8727,10 +8341,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -8738,20 +8351,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -8763,27 +8372,22 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: 'storageClassName is the name
-                                            of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeMode:
-                                          description: volumeMode defines what type
-                                            of volume is required by the claim. Value
-                                            of Filesystem is implied when not included
-                                            in claim spec.
+                                          description: |-
+                                            volumeMode defines what type of volume is required by the claim.
+                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
                                           description: volumeName is the binding reference
@@ -8800,21 +8404,20 @@ spec:
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. TODO: how
-                                    do we prevent errors in the filesystem from compromising
-                                    the machine'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
                                   description: 'targetWWNs is Optional: FC target
@@ -8823,28 +8426,27 @@ spec:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'wwids Optional: FC volume world wide
-                                    identifiers (wwids) Either wwids or combination
-                                    of targetWWNs and lun must be set, but not both
-                                    simultaneously.'
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: flexVolume represents a generic volume
-                                resource that is provisioned/attached using an exec
-                                based plugin.
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
                                   description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". The
-                                    default filesystem depends on FlexVolume script.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
@@ -8853,23 +8455,23 @@ spec:
                                     extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'readOnly is Optional: defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is Optional: secretRef is
-                                    reference to the secret object containing sensitive
-                                    information to pass to the plugin scripts. This
-                                    may be empty if no secret object is specified.
-                                    If the secret object contains more than one secret,
-                                    all secrets are passed to the plugin scripts.'
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugin scripts. This may be
+                                    empty if no secret object is specified. If the secret object
+                                    contains more than one secret, all secrets are passed to the plugin
+                                    scripts.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -8882,9 +8484,9 @@ spec:
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: datasetName is Name of the dataset
-                                    stored as metadata -> name on the dataset for
-                                    Flocker should be considered as deprecated
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -8892,57 +8494,55 @@ spec:
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'gcePersistentDisk represents a GCE Disk
-                                resource that is attached to a kubelet''s host machine
-                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: 'fsType is filesystem type of the volume
-                                    that you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'pdName is unique name of the PD resource
-                                    in GCE. Used to identify the disk in GCE. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'gitRepo represents a git repository at
-                                a particular revision. DEPRECATED: GitRepo is deprecated.
-                                To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo
-                                using git, then mount the EmptyDir into the Pod''s
-                                container.'
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is
-                                    supplied, the volume directory will be the git
-                                    repository.  Otherwise, if specified, the volume
-                                    will contain the git repository in the subdirectory
-                                    with the given name.
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                    the subdirectory with the given name.
                                   type: string
                                 repository:
                                   description: repository is the URL
@@ -8955,54 +8555,61 @@ spec:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'glusterfs represents a Glusterfs mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: 'endpoints is the endpoint name that
-                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: 'path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the Glusterfs
-                                    volume to be mounted with read-only permissions.
-                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'hostPath represents a pre-existing file
-                                or directory on the host machine that is directly
-                                exposed to the container. This is generally used for
-                                system agents or other privileged things that are
-                                allowed to see the host machine. Most containers will
-                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                --- TODO(jonesdl) We need to restrict who can use
-                                host directory mounts and who can/can not mount host
-                                directories as read/write.'
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container. This is generally
+                                used for system agents or other privileged things that are allowed
+                                to see the host machine. Most containers will NOT need this.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                ---
+                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: 'path of the directory on the host.
-                                    If the path is a symlink, it will follow the link
-                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: 'type for HostPath Volume Defaults
-                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'iscsi represents an ISCSI Disk resource
-                                that is attached to a kubelet''s host machine and
-                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -9013,62 +8620,59 @@ spec:
                                     iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: initiatorName is the custom iSCSI Initiator
-                                    Name. If initiatorName is specified with iscsiInterface
-                                    simultaneously, new iSCSI interface <target portal>:<volume
-                                    name> will be created for the connection.
+                                  description: |-
+                                    initiatorName is the custom iSCSI Initiator Name.
+                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
                                   description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iscsiInterface is the interface Name
-                                    that uses an iSCSI transport. Defaults to 'default'
-                                    (tcp).
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: portals is the iSCSI Target Portal
-                                    List. The portal is either an IP or ip_addr:port
-                                    if the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false.
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
                                   type: boolean
                                 secretRef:
                                   description: secretRef is the CHAP Secret for iSCSI
                                     target and initiator authentication
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: targetPortal is iSCSI Target Portal.
-                                    The Portal is either an IP or ip_addr:port if
-                                    the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -9076,43 +8680,51 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'name of the volume. Must be a DNS_LABEL
-                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             nfs:
-                              description: 'nfs represents an NFS mount on the host
-                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: 'path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the NFS export
-                                    to be mounted with read-only permissions. Defaults
-                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: 'server is the hostname or IP address
-                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'persistentVolumeClaimVolumeSource represents
-                                a reference to a PersistentVolumeClaim in the same
-                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: 'claimName is the name of a PersistentVolumeClaim
-                                    in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: readOnly Will force the ReadOnly setting
-                                    in VolumeMounts. Default false.
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
                                   type: boolean
                               required:
                               - claimName
@@ -9123,10 +8735,10 @@ spec:
                                 machine
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
                                   description: pdID is the ID that identifies Photon
@@ -9140,15 +8752,15 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fSType represents the filesystem type
-                                    to mount Must be a filesystem type supported by
-                                    the host operating system. Ex. "ext4", "xfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
                                   description: volumeID uniquely identifies a Portworx
@@ -9162,16 +8774,13 @@ spec:
                                 secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: defaultMode are the mode bits used
-                                    to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Directories within the path
-                                    are not affected by this setting. This might be
-                                    in conflict with other options that affect the
-                                    file mode, like fsGroup, and the result can be
-                                    other mode bits set.
+                                  description: |-
+                                    defaultMode are the mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
@@ -9185,19 +8794,14 @@ spec:
                                           configMap data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced ConfigMap will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the ConfigMap, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the ConfigMap,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -9206,29 +8810,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -9236,10 +8832,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional specify whether
@@ -9280,20 +8876,13 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file, must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -9306,12 +8895,9 @@ spec:
                                                     start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: 'Selects a resource
-                                                    of the container: only resources
-                                                    limits and requests (limits.cpu,
-                                                    limits.memory, requests.cpu and
-                                                    requests.memory) are currently
-                                                    supported.'
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
                                                       description: 'Container name:
@@ -9345,19 +8931,14 @@ spec:
                                           secret data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced Secret will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the Secret, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the Secret,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -9366,29 +8947,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -9396,10 +8969,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional field specify whether
@@ -9412,32 +8985,26 @@ spec:
                                           about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: audience is the intended
-                                              audience of the token. A recipient of
-                                              a token must identify itself with an
-                                              identifier specified in the audience
-                                              of the token, and otherwise should reject
-                                              the token. The audience defaults to
-                                              the identifier of the apiserver.
+                                            description: |-
+                                              audience is the intended audience of the token. A recipient of a token
+                                              must identify itself with an identifier specified in the audience of the
+                                              token, and otherwise should reject the token. The audience defaults to the
+                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: expirationSeconds is the
-                                              requested duration of validity of the
-                                              service account token. As the token
-                                              approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service
-                                              account token. The kubelet will start
-                                              trying to rotate the token if the token
-                                              is older than 80 percent of its time
-                                              to live or if the token is older than
-                                              24 hours.Defaults to 1 hour and must
-                                              be at least 10 minutes.
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token. As the token approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service account token. The kubelet will
+                                              start trying to rotate the token if the token is older than 80 percent of
+                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: path is the path relative
-                                              to the mount point of the file to project
-                                              the token into.
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -9450,29 +9017,30 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: group to map volume access to Default
-                                    is no group
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: readOnly here will force the Quobyte
-                                    volume to be mounted with read-only permissions.
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: registry represents a single or multiple
-                                    Quobyte Registry services specified as a string
-                                    as host:port pair (multiple entries are separated
-                                    with commas) which acts as the central registry
-                                    for volumes
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple entries are separated with commas)
+                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: tenant owning the given Quobyte volume
-                                    in the Backend Used with dynamically provisioned
-                                    Quobyte volumes, value is set by the plugin
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: user to map volume access to Defaults
-                                    to serivceaccount user
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
                                   description: volume is a string that references
@@ -9483,60 +9051,68 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'rbd represents a Rados Block Device mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md'
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: 'image is the rados image name. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: 'keyring is the path to key ring for
-                                    RBDUser. Default is /etc/ceph/keyring. More info:
-                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: 'monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'pool is the rados pool name. Default
-                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is name of the authentication
-                                    secret for RBDUser. If provided overrides keyring.
-                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is the rados user name. Default
-                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
@@ -9547,10 +9123,11 @@ spec:
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
-                                    is "xfs".
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs".
+                                    Default is "xfs".
                                   type: string
                                 gateway:
                                   description: gateway is the host address of the
@@ -9561,21 +9138,20 @@ spec:
                                     ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef references to the secret
-                                    for ScaleIO user and other sensitive information.
-                                    If this is not provided, Login operation will
-                                    fail.
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -9584,8 +9160,8 @@ spec:
                                     communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: storageMode indicates whether the storage
-                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                  description: |-
+                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
@@ -9597,9 +9173,9 @@ spec:
                                     as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the name of a volume
-                                    already created in the ScaleIO system that is
-                                    associated with this volume source.
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -9607,34 +9183,30 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'secret represents a secret that should
-                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items If unspecified, each key-value
-                                    pair in the Data field of the referenced Secret
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -9643,25 +9215,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -9673,8 +9241,9 @@ spec:
                                     Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'secretName is the name of the secret
-                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
@@ -9682,44 +9251,42 @@ spec:
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef specifies the secret to use
-                                    for obtaining the StorageOS API credentials.  If
-                                    not specified, default values will be attempted.
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: volumeName is the human-readable name
-                                    of the StorageOS volume.  Volume names are only
-                                    unique within a namespace.
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: volumeNamespace specifies the scope
-                                    of the volume within StorageOS.  If no namespace
-                                    is specified then the Pod's namespace will be
-                                    used.  This allows the Kubernetes name scoping
-                                    to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default
-                                    behaviour. Set to "default" if you are not using
-                                    namespaces within StorageOS. Namespaces that do
-                                    not pre-exist within StorageOS will be created.
+                                  description: |-
+                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                    namespace is specified then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default behaviour.
+                                    Set to "default" if you are not using namespaces within StorageOS.
+                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
@@ -9727,10 +9294,10 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
                                   description: storagePolicyID is the storage Policy
@@ -9756,16 +9323,17 @@ spec:
                 type: object
               runnerTerminationGracePeriodSeconds:
                 default: 30
-                description: Configure the termination grace period for the runner
-                  pod. Use this parameter to allow the Terraform process to gracefully
-                  shutdown. Consider increasing for large, complex or slow-moving
-                  Terraform managed resources.
+                description: |-
+                  Configure the termination grace period for the runner pod. Use this parameter
+                  to allow the Terraform process to gracefully shutdown. Consider increasing for
+                  large, complex or slow-moving Terraform managed resources.
                 format: int64
                 type: integer
               serviceAccountName:
                 default: tf-runner
-                description: Name of a ServiceAccount for the runner Pod to provision
-                  Terraform resources. Default to tf-runner.
+                description: |-
+                  Name of a ServiceAccount for the runner Pod to provision Terraform resources.
+                  Default to tf-runner.
                 type: string
               sourceRef:
                 description: SourceRef is the reference of the source where the Terraform
@@ -9802,9 +9370,9 @@ spec:
                 - human
                 type: string
               suspend:
-                description: Suspend is to tell the controller to suspend subsequent
-                  TF executions, it does not apply to already started executions.
-                  Defaults to false.
+                description: |-
+                  Suspend is to tell the controller to suspend subsequent TF executions,
+                  it does not apply to already started executions. Defaults to false.
                 type: boolean
               targets:
                 description: Targets specify the resource, module or collection of
@@ -9823,43 +9391,56 @@ spec:
                 properties:
                   forceUnlock:
                     default: "no"
-                    description: "ForceUnlock a Terraform state if it has become locked
-                      for any reason. Defaults to `no`. \n This is an Enum and has
-                      the expected values of: \n - auto - yes - no \n WARNING: Only
-                      use `auto` in the cases where you are absolutely certain that
-                      no other system is using this state, you could otherwise end
-                      up in a bad place See https://www.terraform.io/language/state/locking#force-unlock
-                      for more information on the terraform state lock and force unlock."
+                    description: |-
+                      ForceUnlock a Terraform state if it has become locked for any reason. Defaults to `no`.
+
+
+                      This is an Enum and has the expected values of:
+
+
+                      - auto
+                      - yes
+                      - no
+
+
+                      WARNING: Only use `auto` in the cases where you are absolutely certain that
+                      no other system is using this state, you could otherwise end up in a bad place
+                      See https://www.terraform.io/language/state/locking#force-unlock for more
+                      information on the terraform state lock and force unlock.
                     enum:
                     - "yes"
                     - "no"
                     - auto
                     type: string
                   lockIdentifier:
-                    description: "LockIdentifier holds the Identifier required by
-                      Terraform to unlock the state if it ever gets into a locked
-                      state. \n You'll need to put the Lock Identifier in here while
-                      setting ForceUnlock to either `yes` or `auto`. \n Leave this
-                      empty to do nothing, set this to the value of the `Lock Info:
-                      ID: [value]`, e.g. `f2ab685b-f84d-ac0b-a125-378a22877e8d`, to
-                      force unlock the state."
+                    description: |-
+                      LockIdentifier holds the Identifier required by Terraform to unlock the state
+                      if it ever gets into a locked state.
+
+
+                      You'll need to put the Lock Identifier in here while setting ForceUnlock to
+                      either `yes` or `auto`.
+
+
+                      Leave this empty to do nothing, set this to the value of the `Lock Info: ID: [value]`,
+                      e.g. `f2ab685b-f84d-ac0b-a125-378a22877e8d`, to force unlock the state.
                     type: string
                   lockTimeout:
                     default: 0s
-                    description: "LockTimeout is a Duration string that instructs
-                      Terraform to retry acquiring a lock for the specified period
-                      of time before returning an error. The duration syntax is a
-                      number followed by a time unit letter, such as `3s` for three
-                      seconds. \n Defaults to `0s` which will behave as though `LockTimeout`
-                      was not set"
+                    description: |-
+                      LockTimeout is a Duration string that instructs Terraform to retry acquiring a lock for the specified period of
+                      time before returning an error. The duration syntax is a number followed by a time unit letter, such as `3s` for
+                      three seconds.
+
+
+                      Defaults to `0s` which will behave as though `LockTimeout` was not set
                     type: string
                 type: object
               values:
-                description: Values map to the Terraform variable "values", which
-                  is an object of arbitrary values. It is a convenient way to pass
-                  values to Terraform resources without having to define a variable
-                  for each value. To use this feature, your Terraform file must define
-                  the variable "values".
+                description: |-
+                  Values map to the Terraform variable "values", which is an object of arbitrary values.
+                  It is a convenient way to pass values to Terraform resources without having to define
+                  a variable for each value. To use this feature, your Terraform file must define the variable "values".
                 x-kubernetes-preserve-unknown-fields: true
               vars:
                 description: List of input variables to set for the Terraform program.
@@ -9881,8 +9462,10 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -9893,10 +9476,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
-                          description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
                               description: Version of the schema the FieldPath is
@@ -9911,10 +9493,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
-                          description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
                               description: 'Container name: required for volumes,
@@ -9943,8 +9524,10 @@ spec:
                                 be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must
@@ -9960,14 +9543,14 @@ spec:
                   type: object
                 type: array
               varsFrom:
-                description: List of references to a Secret or a ConfigMap to generate
-                  variables for Terraform resources based on its data, selectively
-                  by varsKey. Values of the later Secret / ConfigMap with the same
-                  keys will override those of the former.
+                description: |-
+                  List of references to a Secret or a ConfigMap to generate variables for
+                  Terraform resources based on its data, selectively by varsKey. Values of the later
+                  Secret / ConfigMap with the same keys will override those of the former.
                 items:
-                  description: VarsReference contain a reference of a Secret or a
-                    ConfigMap to generate variables for Terraform resources based
-                    on its data, selectively by varsKey.
+                  description: |-
+                    VarsReference contain a reference of a Secret or a ConfigMap to generate
+                    variables for Terraform resources based on its data, selectively by varsKey.
                   properties:
                     kind:
                       description: Kind of the values referent, valid values are ('Secret',
@@ -9977,16 +9560,17 @@ spec:
                       - ConfigMap
                       type: string
                     name:
-                      description: Name of the values referent. Should reside in the
-                        same namespace as the referring resource.
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
                       maxLength: 253
                       minLength: 1
                       type: string
                     optional:
-                      description: Optional marks this VarsReference as optional.
-                        When set, a not found error for the values reference is ignored,
-                        but any VarsKey or transient error will still result in a
-                        reconciliation failure.
+                      description: |-
+                        Optional marks this VarsReference as optional. When set, a not found error
+                        for the values reference is ignored, but any VarsKey or
+                        transient error will still result in a reconciliation failure.
                       type: boolean
                     varsKeys:
                       description: VarsKeys is the data key at which a specific value
@@ -10045,9 +9629,9 @@ spec:
                     description: Name is the name of the Secret to be written
                     type: string
                   outputs:
-                    description: Outputs contain the selected names of outputs to
-                      be written to the secret. Empty array means writing all outputs,
-                      which is default.
+                    description: |-
+                      Outputs contain the selected names of outputs to be written
+                      to the secret. Empty array means writing all outputs, which is default.
                     items:
                       type: string
                     type: array
@@ -10070,42 +9654,42 @@ spec:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -10119,11 +9703,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -10165,13 +9750,15 @@ spec:
                 - entries
                 type: object
               lastAppliedByDriftDetectionAt:
-                description: LastAppliedByDriftDetectionAt is the time when the last
-                  drift was detected and terraform apply was performed as a result
+                description: |-
+                  LastAppliedByDriftDetectionAt is the time when the last drift was detected and
+                  terraform apply was performed as a result
                 format: date-time
                 type: string
               lastAppliedRevision:
-                description: The last successfully applied revision. The revision
-                  format for Git sources is <branch|tag>/<commit-sha>.
+                description: |-
+                  The last successfully applied revision.
+                  The revision format for Git sources is <branch|tag>/<commit-sha>.
                 type: string
               lastAttemptedRevision:
                 description: LastAttemptedRevision is the revision of the last reconciliation
@@ -10183,9 +9770,10 @@ spec:
                 format: date-time
                 type: string
               lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value can
-                  be detected.
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
                 type: string
               lastPlanAt:
                 description: LastPlanAt is the time when the last terraform plan was
@@ -10193,9 +9781,9 @@ spec:
                 format: date-time
                 type: string
               lastPlannedRevision:
-                description: LastPlannedRevision is the revision used by the last
-                  planning process. The result could be either no plan change or a
-                  new plan generated.
+                description: |-
+                  LastPlannedRevision is the revision used by the last planning process.
+                  The result could be either no plan change or a new plan generated.
                 type: string
               lock:
                 description: LockStatus defines the observed state of a Terraform
@@ -10224,7 +9812,8 @@ spec:
                     type: string
                 type: object
               reconciliationFailures:
-                description: ReconciliationFailures is the number of reconciliation
+                description: |-
+                  ReconciliationFailures is the number of reconciliation
                   failures since the last success or update.
                 format: int64
                 type: integer

--- a/charts/tofu-controller/templates/deployment.yaml
+++ b/charts/tofu-controller/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
         - --allow-break-the-glass={{ .Values.allowBreakTheGlass }}
         - --cluster-domain={{ .Values.clusterDomain }}
         - --use-pod-subdomain-resolution={{ .Values.usePodSubdomainResolution }}
+        - --exec-type={{ .Values.execType }}
         command:
         - /sbin/tini
         - --

--- a/charts/tofu-controller/values.yaml
+++ b/charts/tofu-controller/values.yaml
@@ -173,6 +173,10 @@ metrics:
       metricRelabelings: []
       # -- Set relabelings for the endpoint of the serviceMonitor
       relabelings: []
+
+# -- ExecType specifies the type of executable used for the operations. It can be either `terraform` or `tofu`.
+execType: terraform
+
 # -- Branch Planner-specific configurations
 branchPlanner:
   enabled: false

--- a/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
+++ b/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: terraforms.infra.contrib.fluxcd.io
 spec:
   group: infra.contrib.fluxcd.io
@@ -35,14 +34,19 @@ spec:
         description: Terraform is the Schema for the terraforms API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -54,9 +58,9 @@ spec:
                 description: Clean the runner pod up after each reconciliation cycle
                 type: boolean
               approvePlan:
-                description: ApprovePlan specifies name of a plan wanted to approve.
-                  If its value is "auto", the controller will automatically approve
-                  every plan.
+                description: |-
+                  ApprovePlan specifies name of a plan wanted to approve.
+                  If its value is "auto", the controller will automatically approve every plan.
                 type: string
               backendConfig:
                 description: BackendConfigSpec is for specifying configuration for
@@ -95,16 +99,17 @@ spec:
                       - ConfigMap
                       type: string
                     name:
-                      description: Name of the configs referent. Should reside in
-                        the same namespace as the referring resource.
+                      description: |-
+                        Name of the configs referent. Should reside in the same namespace as the
+                        referring resource.
                       maxLength: 253
                       minLength: 1
                       type: string
                     optional:
-                      description: Optional marks this BackendConfigsReference as
-                        optional. When set, a not found error for the values reference
-                        is ignored, but any Key or transient error will still result
-                        in a reconciliation failure.
+                      description: |-
+                        Optional marks this BackendConfigsReference as optional. When set, a not found error
+                        for the values reference is ignored, but any Key or
+                        transient error will still result in a reconciliation failure.
                       type: boolean
                   required:
                   - kind
@@ -112,12 +117,14 @@ spec:
                   type: object
                 type: array
               breakTheGlass:
-                description: BreakTheGlass specifies if the reconciliation should
-                  stop and allow interactive shell in case of emergency.
+                description: |-
+                  BreakTheGlass specifies if the reconciliation should stop
+                  and allow interactive shell in case of emergency.
                 type: boolean
               cliConfigSecretRef:
-                description: SecretReference represents a Secret Reference. It has
-                  enough information to retrieve secret in any namespace
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
                 properties:
                   name:
                     description: name is unique within a namespace to reference a
@@ -152,8 +159,9 @@ spec:
                 type: object
               dependsOn:
                 items:
-                  description: NamespacedObjectReference contains enough information
-                    to locate the referenced Kubernetes resource object in any namespace.
+                  description: |-
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
                   properties:
                     name:
                       description: Name of the referent.
@@ -172,14 +180,15 @@ spec:
                 type: boolean
               destroyResourcesOnDeletion:
                 default: false
-                description: Create destroy plan and apply it to destroy terraform
-                  resources upon deletion of this object. Defaults to false.
+                description: |-
+                  Create destroy plan and apply it to destroy terraform resources
+                  upon deletion of this object. Defaults to false.
                 type: boolean
               disableDriftDetection:
                 default: false
-                description: Disable automatic drift detection. Drift detection may
-                  be resource intensive in the context of a large cluster or complex
-                  Terraform statefile. Defaults to false.
+                description: |-
+                  Disable automatic drift detection. Drift detection may be resource intensive in
+                  the context of a large cluster or complex Terraform statefile. Defaults to false.
                 type: boolean
               enableInventory:
                 description: EnableInventory enables the object to store resource
@@ -224,19 +233,22 @@ spec:
                 type: array
               force:
                 default: false
-                description: Force instructs the controller to unconditionally re-plan
-                  and re-apply TF resources. Defaults to false.
+                description: |-
+                  Force instructs the controller to unconditionally
+                  re-plan and re-apply TF resources. Defaults to false.
                 type: boolean
               healthChecks:
                 description: List of health checks to be performed.
                 items:
-                  description: HealthCheck contains configuration needed to perform
-                    a health check after terraform is applied.
+                  description: |-
+                    HealthCheck contains configuration needed to perform a health check after
+                    terraform is applied.
                   properties:
                     address:
-                      description: Address to perform tcp health check on. Required
-                        when tcp type is specified. Go template can be used to reference
-                        values from the terraform output (e.g. 127.0.0.1:8080, {{.address}}:{{.port}}).
+                      description: |-
+                        Address to perform tcp health check on. Required when tcp type is specified.
+                        Go template can be used to reference values from the terraform output
+                        (e.g. 127.0.0.1:8080, {{.address}}:{{.port}}).
                       type: string
                     name:
                       description: Name of the health check.
@@ -245,23 +257,25 @@ spec:
                       type: string
                     timeout:
                       default: 20s
-                      description: The timeout period at which the connection should
-                        timeout if unable to complete the request. When not specified,
-                        default 20s timeout is used.
+                      description: |-
+                        The timeout period at which the connection should timeout if unable to
+                        complete the request.
+                        When not specified, default 20s timeout is used.
                       type: string
                     type:
-                      description: Type of the health check, valid values are ('tcp',
-                        'http'). If tcp is specified, address is required. If http
-                        is specified, url is required.
+                      description: |-
+                        Type of the health check, valid values are ('tcp', 'http').
+                        If tcp is specified, address is required.
+                        If http is specified, url is required.
                       enum:
                       - tcp
                       - http
                       type: string
                     url:
-                      description: URL to perform http health check on. Required when
-                        http type is specified. Go template can be used to reference
-                        values from the terraform output (e.g. https://example.org,
-                        {{.output_url}}).
+                      description: |-
+                        URL to perform http health check on. Required when http type is specified.
+                        Go template can be used to reference values from the terraform output
+                        (e.g. https://example.org, {{.output_url}}).
                       type: string
                   required:
                   - name
@@ -278,7 +292,8 @@ spec:
                 format: int32
                 type: integer
               path:
-                description: Path to the directory containing Terraform (.tf) files.
+                description: |-
+                  Path to the directory containing Terraform (.tf) files.
                   Defaults to 'None', which translates to the root path of the SourceRef.
                 type: string
               readInputsFromSecrets:
@@ -299,7 +314,8 @@ spec:
                   the apply step.
                 type: boolean
               retryInterval:
-                description: The interval at which to retry a previously failed reconciliation.
+                description: |-
+                  The interval at which to retry a previously failed reconciliation.
                   The default value is 15 when not specified.
                 type: string
               runnerPodTemplate:
@@ -327,23 +343,20 @@ spec:
                               for the pod.
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node matches the corresponding matchExpressions;
-                                  the node(s) with the highest sum are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
-                                  description: An empty preferred scheduling term
-                                    matches all objects with implicit weight 0 (i.e.
-                                    it's a no-op). A null preferred scheduling term
-                                    matches no objects (i.e. is also a no-op).
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
                                     preference:
                                       description: A node selector term, associated
@@ -353,32 +366,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -391,32 +398,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -439,53 +440,46 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to an update), the system may or may not try
-                                  to eventually evict the pod from its node.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
                                       terms. The terms are ORed.
                                     items:
-                                      description: A null or empty node selector term
-                                        matches no objects. The requirements of them
-                                        are ANDed. The TopologySelectorTerm type implements
-                                        a subset of the NodeSelectorTerm.
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                       properties:
                                         matchExpressions:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -498,32 +492,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -546,19 +534,16 @@ spec:
                               other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -577,10 +562,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -588,20 +572,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -613,36 +593,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -650,20 +623,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -675,46 +644,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -723,25 +683,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to a pod label update), the system may or may
-                                  not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes
-                                  corresponding to each podAffinityTerm are intersected,
-                                  i.e. all terms must be satisfied.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -752,30 +709,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -787,53 +739,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -845,34 +789,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -886,19 +824,16 @@ spec:
                               etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the anti-affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity
-                                  expressions, etc.), compute a sum by iterating through
-                                  the elements of this field and adding "weight" to
-                                  the sum if the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -917,10 +852,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -928,20 +862,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -953,36 +883,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -990,20 +913,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1015,46 +934,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -1063,25 +973,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the anti-affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  anti-affinity requirements specified by this field
-                                  cease to be met at some point during pod execution
-                                  (e.g. due to a pod label update), the system may
-                                  or may not try to eventually evict the pod from
-                                  its node. When there are multiple elements, the
-                                  lists of nodes corresponding to each podAffinityTerm
-                                  are intersected, i.e. all terms must be satisfied.
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -1092,30 +999,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1127,53 +1029,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1185,34 +1079,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -1222,7 +1110,8 @@ spec:
                             type: object
                         type: object
                       env:
-                        description: List of environment variables to set in the container.
+                        description: |-
+                          List of environment variables to set in the container.
                           Cannot be updated.
                         items:
                           description: EnvVar represents an environment variable present
@@ -1233,16 +1122,16 @@ spec:
                                 be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables
-                                in the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. Double $$ are
-                                reduced to a single $, which allows for escaping the
-                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Defaults to "".'
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -1255,10 +1144,10 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -1269,11 +1158,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
                                       description: Version of the schema the FieldPath
@@ -1288,11 +1175,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -1322,10 +1207,10 @@ spec:
                                         from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -1341,13 +1226,13 @@ spec:
                           type: object
                         type: array
                       envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must
-                          be a C_IDENTIFIER. All invalid keys will be reported as
-                          an event when the container is starting. When a key exists
-                          in multiple sources, the value associated with the last
-                          source will take precedence. Values defined by an Env with
-                          a duplicate key will take precedence. Cannot be updated.
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -1356,9 +1241,10 @@ spec:
                               description: The ConfigMap to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must
@@ -1374,9 +1260,10 @@ spec:
                               description: The Secret to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be
@@ -1396,38 +1283,35 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The container
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The container image''s ENTRYPOINT is used
-                                if this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -1437,17 +1321,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -1460,10 +1343,10 @@ spec:
                                             description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -1474,11 +1357,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                         properties:
                                           apiVersion:
                                             description: Version of the schema the
@@ -1494,11 +1375,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -1530,10 +1409,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -1549,14 +1428,13 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -1565,10 +1443,10 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -1584,10 +1462,10 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -1598,44 +1476,42 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                This field is optional to allow higher level config
-                                management to default or override container images
-                                in workload controllers like Deployments and StatefulSets.'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
-                              description: Actions that the management system should
-                                take in response to container lifecycle events. Cannot
-                                be updated.
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -1645,8 +1521,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -1657,10 +1533,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -1678,24 +1553,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -1705,44 +1580,37 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -1752,8 +1620,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -1764,10 +1632,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -1785,24 +1652,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -1812,10 +1679,10 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -1823,30 +1690,29 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness.
-                                Container will be restarted if the probe fails. Cannot
-                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -1860,11 +1726,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -1874,9 +1741,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -1886,10 +1753,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -1906,34 +1772,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -1948,61 +1815,59 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL.
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
                                 Each container in a pod must have a unique name (DNS_LABEL).
                                 Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container.
-                                Not specifying a port here DOES NOT prevent that port
-                                from being exposed. Any port which is listening on
-                                the default "0.0.0.0" address inside a container will
-                                be accessible from the network. Modifying this array
-                                with strategic merge patch may corrupt the data. For
-                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                 Cannot be updated.
                               items:
                                 description: ContainerPort represents a network port
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -2010,23 +1875,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -2037,30 +1903,29 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness.
-                                Container will be removed from service endpoints if
-                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -2074,11 +1939,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -2088,9 +1954,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -2100,10 +1966,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -2120,34 +1985,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -2162,36 +2028,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -2202,14 +2065,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -2218,25 +2081,31 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -2252,8 +2121,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -2262,35 +2132,34 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             securityContext:
-                              description: 'SecurityContext defines the security options
-                                the container should be run with. If set, the fields
-                                of SecurityContext override the equivalent fields
-                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -2308,66 +2177,60 @@ spec:
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -2387,107 +2250,95 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must only be set if type is "Localhost".
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must only be set if type is "Localhost".
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        This field is alpha-level and will only be
-                                        honored by components that enable the WindowsHostProcessContainers
-                                        feature flag. Setting this field without the
-                                        feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be honored by components that enable the
+                                        WindowsHostProcessContainers feature flag. Setting this field without the feature
+                                        flag will result in errors when validating the Pod. All of a Pod's containers must
+                                        have the same effective HostProcess value (it is not allowed to have a mix of HostProcess
+                                        containers and non-HostProcess containers).  In addition, if HostProcess is true
+                                        then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has
-                                successfully initialized. If specified, no other probes
-                                are executed until this completes successfully. If
-                                this probe fails, the Pod will be restarted, just
-                                as if the livenessProbe failed. This can be used to
-                                provide different probe parameters at the beginning
-                                of a Pod''s lifecycle, when it might take a long time
-                                to load data or warm a cache, than during steady-state
-                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -2501,11 +2352,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -2515,9 +2367,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -2527,10 +2379,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -2547,34 +2398,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -2589,83 +2441,75 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -2690,44 +2534,44 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -2735,10 +2579,11 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
@@ -2752,42 +2597,39 @@ spec:
                       tolerations:
                         description: Set the Tolerations for the Runner Pod
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -2798,34 +2640,36 @@ spec:
                             within a container.
                           properties:
                             mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
                               type: string
                             name:
                               description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                           - mountPath
@@ -2839,37 +2683,36 @@ spec:
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'awsElasticBlockStore represents an AWS
-                                Disk resource that is attached to a kubelet''s host
-                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly value true will force the
-                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: 'volumeID is unique ID of the persistent
-                                    disk resource in AWS (Amazon EBS volume). More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
@@ -2891,10 +2734,10 @@ spec:
                                     the blob storage
                                   type: string
                                 fsType:
-                                  description: fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
                                   description: 'kind expected values are Shared: multiple
@@ -2904,9 +2747,9 @@ spec:
                                     set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
@@ -2917,9 +2760,9 @@ spec:
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
                                   description: secretName is the  name of secret that
@@ -2937,8 +2780,9 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'monitors is Required: Monitors is
-                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
@@ -2948,67 +2792,72 @@ spec:
                                     is /'
                                   type: string
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: 'secretFile is Optional: SecretFile
-                                    is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: 'secretRef is Optional: SecretRef is
-                                    reference to the authentication secret for User,
-                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is optional: User is the rados
-                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'cinder represents a cinder volume attached
-                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Examples: "ext4", "xfs", "ntfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: 'readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is optional: points to a
-                                    secret object containing parameters used to connect
-                                    to OpenStack.'
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: 'volumeID used to identify the volume
-                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
@@ -3018,30 +2867,25 @@ spec:
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items if unspecified, each key-value
-                                    pair in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -3050,25 +2894,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -3076,9 +2916,10 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: optional specify whether the ConfigMap
@@ -3092,45 +2933,43 @@ spec:
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: driver is the name of the CSI driver
-                                    that handles this volume. Consult with your admin
-                                    for the correct name as registered in the cluster.
+                                  description: |-
+                                    driver is the name of the CSI driver that handles this volume.
+                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: fsType to mount. Ex. "ext4", "xfs",
-                                    "ntfs". If not provided, the empty value is passed
-                                    to the associated CSI driver which will determine
-                                    the default filesystem to apply.
+                                  description: |-
+                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated CSI driver
+                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: nodePublishSecretRef is a reference
-                                    to the secret object containing sensitive information
-                                    to pass to the CSI driver to complete the CSI
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no
-                                    secret is required. If the secret object contains
-                                    more than one secret, all secret references are
-                                    passed.
+                                    This field is optional, and  may be empty if no secret is required. If the
+                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: readOnly specifies a read-only configuration
-                                    for the volume. Defaults to false (read/write).
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: volumeAttributes stores driver-specific
-                                    properties that are passed to the CSI driver.
-                                    Consult your driver's documentation for supported
-                                    values.
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
@@ -3140,17 +2979,15 @@ spec:
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits to use on created
-                                    files by default. Must be a Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    Optional: mode bits to use on created files by default. Must be a
+                                    Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
@@ -3180,16 +3017,13 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file, must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
@@ -3200,10 +3034,9 @@ spec:
                                           the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -3231,121 +3064,125 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'emptyDir represents a temporary directory
-                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: 'medium represents what type of storage
-                                    medium should back this directory. The default
-                                    is "" which means to use the node''s default medium.
-                                    Must be an empty string (default) or Memory. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    medium represents what type of storage medium should back this directory.
+                                    The default is "" which means to use the node's default medium.
+                                    Must be an empty string (default) or Memory.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'sizeLimit is the total amount of local
-                                    storage required for this EmptyDir volume. The
-                                    size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would
-                                    be the minimum value between the SizeLimit specified
-                                    here and the sum of memory limits of all containers
-                                    in a pod. The default is nil which means that
-                                    the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                    The size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would be the minimum value between
+                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                    The default is nil which means that the limit is undefined.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "ephemeral represents a volume that is
-                                handled by a cluster storage driver. The volume's
-                                lifecycle is tied to the pod that defines it - it
-                                will be created before the pod starts, and deleted
-                                when the pod is removed. \n Use this if: a) the volume
-                                is only needed while the pod runs, b) features of
-                                normal volumes like restoring from snapshot or capacity
-                                tracking are needed, c) the storage driver is specified
-                                through a storage class, and d) the storage driver
-                                supports dynamic volume provisioning through a PersistentVolumeClaim
-                                (see EphemeralVolumeSource for more information on
-                                the connection between this volume type and PersistentVolumeClaim).
-                                \n Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the
-                                lifecycle of an individual pod. \n Use CSI for light-weight
-                                local ephemeral volumes if the CSI driver is meant
-                                to be used that way - see the documentation of the
-                                driver for more information. \n A pod can use both
-                                types of ephemeral volumes and persistent volumes
-                                at the same time."
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver.
+                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                and deleted when the pod is removed.
+
+
+                                Use this if:
+                                a) the volume is only needed while the pod runs,
+                                b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and
+                                d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+
+                                Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the lifecycle
+                                of an individual pod.
+
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                be used that way - see the documentation of the driver for
+                                more information.
+
+
+                                A pod can use both types of ephemeral volumes and
+                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: "Will be used to create a stand-alone
-                                    PVC to provision the volume. The pod in which
-                                    this EphemeralVolumeSource is embedded will be
-                                    the owner of the PVC, i.e. the PVC will be deleted
-                                    together with the pod.  The name of the PVC will
-                                    be `<pod name>-<volume name>` where `<volume name>`
-                                    is the name from the `PodSpec.Volumes` array entry.
-                                    Pod validation will reject the pod if the concatenated
-                                    name is not valid for a PVC (for example, too
-                                    long). \n An existing PVC with that name that
-                                    is not owned by the pod will *not* be used for
-                                    the pod to avoid using an unrelated volume by
-                                    mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created
-                                    PVC is meant to be used by the pod, the PVC has
-                                    to updated with an owner reference to the pod
-                                    once the pod exists. Normally this should not
-                                    be necessary, but it may be useful when manually
-                                    reconstructing a broken cluster. \n This field
-                                    is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created. \n Required,
-                                    must not be nil."
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume.
+                                    The pod in which this EphemeralVolumeSource is embedded will be the
+                                    owner of the PVC, i.e. the PVC will be deleted together with the
+                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                    `<volume name>` is the name from the `PodSpec.Volumes` array
+                                    entry. Pod validation will reject the pod if the concatenated name
+                                    is not valid for a PVC (for example, too long).
+
+
+                                    An existing PVC with that name that is not owned by the pod
+                                    will *not* be used for the pod to avoid using an unrelated
+                                    volume by mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created PVC is
+                                    meant to be used by the pod, the PVC has to updated with an
+                                    owner reference to the pod once the pod exists. Normally
+                                    this should not be necessary, but it may be useful when
+                                    manually reconstructing a broken cluster.
+
+
+                                    This field is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created.
+
+
+                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: May contain labels and annotations
-                                        that will be copied into the PVC when creating
-                                        it. No other fields are allowed and will be
-                                        rejected during validation.
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it. No other fields are allowed and will be rejected during
+                                        validation.
                                       type: object
                                     spec:
-                                      description: The specification for the PersistentVolumeClaim.
-                                        The entire content is copied unchanged into
-                                        the PVC that gets created from this template.
-                                        The same fields as in a PersistentVolumeClaim
+                                      description: |-
+                                        The specification for the PersistentVolumeClaim. The entire content is
+                                        copied unchanged into the PVC that gets created from this
+                                        template. The same fields as in a PersistentVolumeClaim
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'accessModes contains the desired
-                                            access modes the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'dataSource field can be used
-                                            to specify either: * An existing VolumeSnapshot
-                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller
-                                            can support the specified data source,
-                                            it will create a new volume based on the
-                                            contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate
-                                            is enabled, dataSource contents will be
-                                            copied to dataSourceRef, and dataSourceRef
-                                            contents will be copied to dataSource
-                                            when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef
-                                            will not be copied to dataSource.'
+                                            If the provisioner or an external controller can support the specified data source,
+                                            it will create a new volume based on the contents of the specified data source.
+                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -3361,50 +3198,36 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: 'dataSourceRef specifies the
-                                            object from which to populate the volume
-                                            with data, if a non-empty volume is desired.
-                                            This may be any object from a non-empty
-                                            API group (non core object) or a PersistentVolumeClaim
-                                            object. When this field is specified,
-                                            volume binding will only succeed if the
-                                            type of the specified object matches some
-                                            installed volume populator or dynamic
-                                            provisioner. This field will replace the
-                                            functionality of the dataSource field
-                                            and as such if both fields are non-empty,
-                                            they must have the same value. For backwards
-                                            compatibility, when namespace isn''t specified
-                                            in dataSourceRef, both fields (dataSource
-                                            and dataSourceRef) will be set to the
-                                            same value automatically if one of them
-                                            is empty and the other is non-empty. When
-                                            namespace is specified in dataSourceRef,
-                                            dataSource isn''t set to the same value
-                                            and must be empty. There are three important
-                                            differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific
-                                            types of objects, dataSourceRef allows
-                                            any non-core object, as well as PersistentVolumeClaim
-                                            objects. * While dataSource ignores disallowed
-                                            values (dropping them), dataSourceRef
-                                            preserves all values, and generates an
-                                            error if a disallowed value is specified.
-                                            * While dataSource only allows local objects,
-                                            dataSourceRef allows objects in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource
-                                            feature gate to be enabled. (Alpha) Using
-                                            the namespace field of dataSourceRef requires
-                                            the CrossNamespaceVolumeDataSource feature
-                                            gate to be enabled.'
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired. This may be any object from a non-empty API group (non
+                                            core object) or a PersistentVolumeClaim object.
+                                            When this field is specified, volume binding will only succeed if the type of
+                                            the specified object matches some installed volume populator or dynamic
+                                            provisioner.
+                                            This field will replace the functionality of the dataSource field and as such
+                                            if both fields are non-empty, they must have the same value. For backwards
+                                            compatibility, when namespace isn't specified in dataSourceRef,
+                                            both fields (dataSource and dataSourceRef) will be set to the same
+                                            value automatically if one of them is empty and the other is non-empty.
+                                            When namespace is specified in dataSourceRef,
+                                            dataSource isn't set to the same value and must be empty.
+                                            There are three important differences between dataSource and dataSourceRef:
+                                            * While dataSource only allows two specific types of objects, dataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            * While dataSource only allows local objects, dataSourceRef allows objects
+                                              in any namespaces.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -3415,50 +3238,43 @@ spec:
                                                 being referenced
                                               type: string
                                             namespace:
-                                              description: Namespace is the namespace
-                                                of resource being referenced Note
-                                                that when a namespace is specified,
-                                                a gateway.networking.k8s.io/ReferenceGrant
-                                                object is required in the referent
-                                                namespace to allow that namespace's
-                                                owner to accept the reference. See
-                                                the ReferenceGrant documentation for
-                                                details. (Alpha) This field requires
-                                                the CrossNamespaceVolumeDataSource
-                                                feature gate to be enabled.
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: 'resources represents the minimum
-                                            resources the volume should have. If RecoverVolumeExpansionFailure
-                                            feature is enabled users are allowed to
-                                            specify resource requirements that are
-                                            lower than previous value but must still
-                                            be higher than capacity recorded in the
-                                            status field of the claim. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: |-
+                                            resources represents the minimum resources the volume should have.
+                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            that are lower than previous value but must still be higher than capacity recorded in the
+                                            status field of the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             claims:
-                                              description: "Claims lists the names
-                                                of resources, defined in spec.resourceClaims,
-                                                that are used by this container. \n
-                                                This is an alpha field and requires
-                                                enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable.
-                                                It can only be set for containers."
+                                              description: |-
+                                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                                that are used by this container.
+
+
+                                                This is an alpha field and requires enabling the
+                                                DynamicResourceAllocation feature gate.
+
+
+                                                This field is immutable. It can only be set for containers.
                                               items:
                                                 description: ResourceClaim references
                                                   one entry in PodSpec.ResourceClaims.
                                                 properties:
                                                   name:
-                                                    description: Name must match the
-                                                      name of one entry in pod.spec.resourceClaims
-                                                      of the Pod where this field
-                                                      is used. It makes that resource
-                                                      available inside a container.
+                                                    description: |-
+                                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                                      the Pod where this field is used. It makes that resource available
+                                                      inside a container.
                                                     type: string
                                                 required:
                                                 - name
@@ -3474,9 +3290,9 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Limits describes the maximum
-                                                amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -3485,14 +3301,11 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Requests describes the
-                                                minimum amount of compute resources
-                                                required. If Requests is omitted for
-                                                a container, it defaults to Limits
-                                                if that is explicitly specified, otherwise
-                                                to an implementation-defined value.
-                                                Requests cannot exceed Limits. More
-                                                info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Requests describes the minimum amount of compute resources required.
+                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
@@ -3504,10 +3317,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -3515,20 +3327,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3540,27 +3348,22 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: 'storageClassName is the name
-                                            of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeMode:
-                                          description: volumeMode defines what type
-                                            of volume is required by the claim. Value
-                                            of Filesystem is implied when not included
-                                            in claim spec.
+                                          description: |-
+                                            volumeMode defines what type of volume is required by the claim.
+                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
                                           description: volumeName is the binding reference
@@ -3577,21 +3380,20 @@ spec:
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. TODO: how
-                                    do we prevent errors in the filesystem from compromising
-                                    the machine'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
                                   description: 'targetWWNs is Optional: FC target
@@ -3600,28 +3402,27 @@ spec:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'wwids Optional: FC volume world wide
-                                    identifiers (wwids) Either wwids or combination
-                                    of targetWWNs and lun must be set, but not both
-                                    simultaneously.'
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: flexVolume represents a generic volume
-                                resource that is provisioned/attached using an exec
-                                based plugin.
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
                                   description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". The
-                                    default filesystem depends on FlexVolume script.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
@@ -3630,23 +3431,23 @@ spec:
                                     extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'readOnly is Optional: defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is Optional: secretRef is
-                                    reference to the secret object containing sensitive
-                                    information to pass to the plugin scripts. This
-                                    may be empty if no secret object is specified.
-                                    If the secret object contains more than one secret,
-                                    all secrets are passed to the plugin scripts.'
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugin scripts. This may be
+                                    empty if no secret object is specified. If the secret object
+                                    contains more than one secret, all secrets are passed to the plugin
+                                    scripts.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3659,9 +3460,9 @@ spec:
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: datasetName is Name of the dataset
-                                    stored as metadata -> name on the dataset for
-                                    Flocker should be considered as deprecated
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -3669,57 +3470,55 @@ spec:
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'gcePersistentDisk represents a GCE Disk
-                                resource that is attached to a kubelet''s host machine
-                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: 'fsType is filesystem type of the volume
-                                    that you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'pdName is unique name of the PD resource
-                                    in GCE. Used to identify the disk in GCE. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'gitRepo represents a git repository at
-                                a particular revision. DEPRECATED: GitRepo is deprecated.
-                                To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo
-                                using git, then mount the EmptyDir into the Pod''s
-                                container.'
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is
-                                    supplied, the volume directory will be the git
-                                    repository.  Otherwise, if specified, the volume
-                                    will contain the git repository in the subdirectory
-                                    with the given name.
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                    the subdirectory with the given name.
                                   type: string
                                 repository:
                                   description: repository is the URL
@@ -3732,54 +3531,61 @@ spec:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'glusterfs represents a Glusterfs mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: 'endpoints is the endpoint name that
-                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: 'path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the Glusterfs
-                                    volume to be mounted with read-only permissions.
-                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'hostPath represents a pre-existing file
-                                or directory on the host machine that is directly
-                                exposed to the container. This is generally used for
-                                system agents or other privileged things that are
-                                allowed to see the host machine. Most containers will
-                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                --- TODO(jonesdl) We need to restrict who can use
-                                host directory mounts and who can/can not mount host
-                                directories as read/write.'
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container. This is generally
+                                used for system agents or other privileged things that are allowed
+                                to see the host machine. Most containers will NOT need this.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                ---
+                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: 'path of the directory on the host.
-                                    If the path is a symlink, it will follow the link
-                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: 'type for HostPath Volume Defaults
-                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'iscsi represents an ISCSI Disk resource
-                                that is attached to a kubelet''s host machine and
-                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -3790,62 +3596,59 @@ spec:
                                     iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: initiatorName is the custom iSCSI Initiator
-                                    Name. If initiatorName is specified with iscsiInterface
-                                    simultaneously, new iSCSI interface <target portal>:<volume
-                                    name> will be created for the connection.
+                                  description: |-
+                                    initiatorName is the custom iSCSI Initiator Name.
+                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
                                   description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iscsiInterface is the interface Name
-                                    that uses an iSCSI transport. Defaults to 'default'
-                                    (tcp).
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: portals is the iSCSI Target Portal
-                                    List. The portal is either an IP or ip_addr:port
-                                    if the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false.
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
                                   type: boolean
                                 secretRef:
                                   description: secretRef is the CHAP Secret for iSCSI
                                     target and initiator authentication
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: targetPortal is iSCSI Target Portal.
-                                    The Portal is either an IP or ip_addr:port if
-                                    the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -3853,43 +3656,51 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'name of the volume. Must be a DNS_LABEL
-                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             nfs:
-                              description: 'nfs represents an NFS mount on the host
-                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: 'path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the NFS export
-                                    to be mounted with read-only permissions. Defaults
-                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: 'server is the hostname or IP address
-                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'persistentVolumeClaimVolumeSource represents
-                                a reference to a PersistentVolumeClaim in the same
-                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: 'claimName is the name of a PersistentVolumeClaim
-                                    in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: readOnly Will force the ReadOnly setting
-                                    in VolumeMounts. Default false.
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
                                   type: boolean
                               required:
                               - claimName
@@ -3900,10 +3711,10 @@ spec:
                                 machine
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
                                   description: pdID is the ID that identifies Photon
@@ -3917,15 +3728,15 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fSType represents the filesystem type
-                                    to mount Must be a filesystem type supported by
-                                    the host operating system. Ex. "ext4", "xfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
                                   description: volumeID uniquely identifies a Portworx
@@ -3939,16 +3750,13 @@ spec:
                                 secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: defaultMode are the mode bits used
-                                    to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Directories within the path
-                                    are not affected by this setting. This might be
-                                    in conflict with other options that affect the
-                                    file mode, like fsGroup, and the result can be
-                                    other mode bits set.
+                                  description: |-
+                                    defaultMode are the mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
@@ -3962,19 +3770,14 @@ spec:
                                           configMap data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced ConfigMap will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the ConfigMap, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the ConfigMap,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -3983,29 +3786,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -4013,10 +3808,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional specify whether
@@ -4057,20 +3852,13 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file, must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -4083,12 +3871,9 @@ spec:
                                                     start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: 'Selects a resource
-                                                    of the container: only resources
-                                                    limits and requests (limits.cpu,
-                                                    limits.memory, requests.cpu and
-                                                    requests.memory) are currently
-                                                    supported.'
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
                                                       description: 'Container name:
@@ -4122,19 +3907,14 @@ spec:
                                           secret data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced Secret will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the Secret, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the Secret,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -4143,29 +3923,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -4173,10 +3945,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional field specify whether
@@ -4189,32 +3961,26 @@ spec:
                                           about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: audience is the intended
-                                              audience of the token. A recipient of
-                                              a token must identify itself with an
-                                              identifier specified in the audience
-                                              of the token, and otherwise should reject
-                                              the token. The audience defaults to
-                                              the identifier of the apiserver.
+                                            description: |-
+                                              audience is the intended audience of the token. A recipient of a token
+                                              must identify itself with an identifier specified in the audience of the
+                                              token, and otherwise should reject the token. The audience defaults to the
+                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: expirationSeconds is the
-                                              requested duration of validity of the
-                                              service account token. As the token
-                                              approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service
-                                              account token. The kubelet will start
-                                              trying to rotate the token if the token
-                                              is older than 80 percent of its time
-                                              to live or if the token is older than
-                                              24 hours.Defaults to 1 hour and must
-                                              be at least 10 minutes.
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token. As the token approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service account token. The kubelet will
+                                              start trying to rotate the token if the token is older than 80 percent of
+                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: path is the path relative
-                                              to the mount point of the file to project
-                                              the token into.
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -4227,29 +3993,30 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: group to map volume access to Default
-                                    is no group
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: readOnly here will force the Quobyte
-                                    volume to be mounted with read-only permissions.
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: registry represents a single or multiple
-                                    Quobyte Registry services specified as a string
-                                    as host:port pair (multiple entries are separated
-                                    with commas) which acts as the central registry
-                                    for volumes
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple entries are separated with commas)
+                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: tenant owning the given Quobyte volume
-                                    in the Backend Used with dynamically provisioned
-                                    Quobyte volumes, value is set by the plugin
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: user to map volume access to Defaults
-                                    to serivceaccount user
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
                                   description: volume is a string that references
@@ -4260,60 +4027,68 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'rbd represents a Rados Block Device mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md'
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: 'image is the rados image name. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: 'keyring is the path to key ring for
-                                    RBDUser. Default is /etc/ceph/keyring. More info:
-                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: 'monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'pool is the rados pool name. Default
-                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is name of the authentication
-                                    secret for RBDUser. If provided overrides keyring.
-                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is the rados user name. Default
-                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
@@ -4324,10 +4099,11 @@ spec:
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
-                                    is "xfs".
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs".
+                                    Default is "xfs".
                                   type: string
                                 gateway:
                                   description: gateway is the host address of the
@@ -4338,21 +4114,20 @@ spec:
                                     ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef references to the secret
-                                    for ScaleIO user and other sensitive information.
-                                    If this is not provided, Login operation will
-                                    fail.
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -4361,8 +4136,8 @@ spec:
                                     communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: storageMode indicates whether the storage
-                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                  description: |-
+                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
@@ -4374,9 +4149,9 @@ spec:
                                     as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the name of a volume
-                                    already created in the ScaleIO system that is
-                                    associated with this volume source.
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -4384,34 +4159,30 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'secret represents a secret that should
-                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items If unspecified, each key-value
-                                    pair in the Data field of the referenced Secret
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -4420,25 +4191,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -4450,8 +4217,9 @@ spec:
                                     Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'secretName is the name of the secret
-                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
@@ -4459,44 +4227,42 @@ spec:
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef specifies the secret to use
-                                    for obtaining the StorageOS API credentials.  If
-                                    not specified, default values will be attempted.
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: volumeName is the human-readable name
-                                    of the StorageOS volume.  Volume names are only
-                                    unique within a namespace.
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: volumeNamespace specifies the scope
-                                    of the volume within StorageOS.  If no namespace
-                                    is specified then the Pod's namespace will be
-                                    used.  This allows the Kubernetes name scoping
-                                    to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default
-                                    behaviour. Set to "default" if you are not using
-                                    namespaces within StorageOS. Namespaces that do
-                                    not pre-exist within StorageOS will be created.
+                                  description: |-
+                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                    namespace is specified then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default behaviour.
+                                    Set to "default" if you are not using namespaces within StorageOS.
+                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
@@ -4504,10 +4270,10 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
                                   description: storagePolicyID is the storage Policy
@@ -4533,16 +4299,17 @@ spec:
                 type: object
               runnerTerminationGracePeriodSeconds:
                 default: 30
-                description: Configure the termination grace period for the runner
-                  pod. Use this parameter to allow the Terraform process to gracefully
-                  shutdown. Consider increasing for large, complex or slow-moving
-                  Terraform managed resources.
+                description: |-
+                  Configure the termination grace period for the runner pod. Use this parameter
+                  to allow the Terraform process to gracefully shutdown. Consider increasing for
+                  large, complex or slow-moving Terraform managed resources.
                 format: int64
                 type: integer
               serviceAccountName:
                 default: tf-runner
-                description: Name of a ServiceAccount for the runner Pod to provision
-                  Terraform resources. Default to tf-runner.
+                description: |-
+                  Name of a ServiceAccount for the runner Pod to provision Terraform resources.
+                  Default to tf-runner.
                 type: string
               sourceRef:
                 description: SourceRef is the reference of the source where the Terraform
@@ -4579,9 +4346,9 @@ spec:
                 - human
                 type: string
               suspend:
-                description: Suspend is to tell the controller to suspend subsequent
-                  TF executions, it does not apply to already started executions.
-                  Defaults to false.
+                description: |-
+                  Suspend is to tell the controller to suspend subsequent TF executions,
+                  it does not apply to already started executions. Defaults to false.
                 type: boolean
               targets:
                 description: Targets specify the resource, module or collection of
@@ -4594,34 +4361,46 @@ spec:
                 properties:
                   forceUnlock:
                     default: "no"
-                    description: "ForceUnlock a Terraform state if it has become locked
-                      for any reason. Defaults to `no`. \n This is an Enum and has
-                      the expected values of: \n - auto - yes - no \n WARNING: Only
-                      use `auto` in the cases where you are absolutely certain that
-                      no other system is using this state, you could otherwise end
-                      up in a bad place See https://www.terraform.io/language/state/locking#force-unlock
-                      for more information on the terraform state lock and force unlock."
+                    description: |-
+                      ForceUnlock a Terraform state if it has become locked for any reason. Defaults to `no`.
+
+
+                      This is an Enum and has the expected values of:
+
+
+                      - auto
+                      - yes
+                      - no
+
+
+                      WARNING: Only use `auto` in the cases where you are absolutely certain that
+                      no other system is using this state, you could otherwise end up in a bad place
+                      See https://www.terraform.io/language/state/locking#force-unlock for more
+                      information on the terraform state lock and force unlock.
                     enum:
                     - "yes"
                     - "no"
                     - auto
                     type: string
                   lockIdentifier:
-                    description: "LockIdentifier holds the Identifier required by
-                      Terraform to unlock the state if it ever gets into a locked
-                      state. \n You'll need to put the Lock Identifier in here while
-                      setting ForceUnlock to either `yes` or `auto`. \n Leave this
-                      empty to do nothing, set this to the value of the `Lock Info:
-                      ID: [value]`, e.g. `f2ab685b-f84d-ac0b-a125-378a22877e8d`, to
-                      force unlock the state."
+                    description: |-
+                      LockIdentifier holds the Identifier required by Terraform to unlock the state
+                      if it ever gets into a locked state.
+
+
+                      You'll need to put the Lock Identifier in here while setting ForceUnlock to
+                      either `yes` or `auto`.
+
+
+                      Leave this empty to do nothing, set this to the value of the `Lock Info: ID: [value]`,
+                      e.g. `f2ab685b-f84d-ac0b-a125-378a22877e8d`, to force unlock the state.
                     type: string
                 type: object
               values:
-                description: Values map to the Terraform variable "values", which
-                  is an object of arbitrary values. It is a convenient way to pass
-                  values to Terraform resources without having to define a variable
-                  for each value. To use this feature, your Terraform file must define
-                  the variable "values".
+                description: |-
+                  Values map to the Terraform variable "values", which is an object of arbitrary values.
+                  It is a convenient way to pass values to Terraform resources without having to define
+                  a variable for each value. To use this feature, your Terraform file must define the variable "values".
                 x-kubernetes-preserve-unknown-fields: true
               vars:
                 description: List of input variables to set for the Terraform program.
@@ -4643,8 +4422,10 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -4655,10 +4436,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
-                          description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
                               description: Version of the schema the FieldPath is
@@ -4673,10 +4453,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
-                          description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
                               description: 'Container name: required for volumes,
@@ -4705,8 +4484,10 @@ spec:
                                 be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must
@@ -4722,14 +4503,14 @@ spec:
                   type: object
                 type: array
               varsFrom:
-                description: List of references to a Secret or a ConfigMap to generate
-                  variables for Terraform resources based on its data, selectively
-                  by varsKey. Values of the later Secret / ConfigMap with the same
-                  keys will override those of the former.
+                description: |-
+                  List of references to a Secret or a ConfigMap to generate variables for
+                  Terraform resources based on its data, selectively by varsKey. Values of the later
+                  Secret / ConfigMap with the same keys will override those of the former.
                 items:
-                  description: VarsReference contain a reference of a Secret or a
-                    ConfigMap to generate variables for Terraform resources based
-                    on its data, selectively by varsKey.
+                  description: |-
+                    VarsReference contain a reference of a Secret or a ConfigMap to generate
+                    variables for Terraform resources based on its data, selectively by varsKey.
                   properties:
                     kind:
                       description: Kind of the values referent, valid values are ('Secret',
@@ -4739,16 +4520,17 @@ spec:
                       - ConfigMap
                       type: string
                     name:
-                      description: Name of the values referent. Should reside in the
-                        same namespace as the referring resource.
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
                       maxLength: 253
                       minLength: 1
                       type: string
                     optional:
-                      description: Optional marks this VarsReference as optional.
-                        When set, a not found error for the values reference is ignored,
-                        but any VarsKey or transient error will still result in a
-                        reconciliation failure.
+                      description: |-
+                        Optional marks this VarsReference as optional. When set, a not found error
+                        for the values reference is ignored, but any VarsKey or
+                        transient error will still result in a reconciliation failure.
                       type: boolean
                     varsKeys:
                       description: VarsKeys is the data key at which a specific value
@@ -4797,9 +4579,9 @@ spec:
                     description: Name is the name of the Secret to be written
                     type: string
                   outputs:
-                    description: Outputs contain the selected names of outputs to
-                      be written to the secret. Empty array means writing all outputs,
-                      which is default.
+                    description: |-
+                      Outputs contain the selected names of outputs to be written
+                      to the secret. Empty array means writing all outputs, which is default.
                     items:
                       type: string
                     type: array
@@ -4820,42 +4602,42 @@ spec:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -4869,11 +4651,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -4915,13 +4698,15 @@ spec:
                 - entries
                 type: object
               lastAppliedByDriftDetectionAt:
-                description: LastAppliedByDriftDetectionAt is the time when the last
-                  drift was detected and terraform apply was performed as a result
+                description: |-
+                  LastAppliedByDriftDetectionAt is the time when the last drift was detected and
+                  terraform apply was performed as a result
                 format: date-time
                 type: string
               lastAppliedRevision:
-                description: The last successfully applied revision. The revision
-                  format for Git sources is <branch|tag>/<commit-sha>.
+                description: |-
+                  The last successfully applied revision.
+                  The revision format for Git sources is <branch|tag>/<commit-sha>.
                 type: string
               lastAttemptedRevision:
                 description: LastAttemptedRevision is the revision of the last reconciliation
@@ -4933,14 +4718,15 @@ spec:
                 format: date-time
                 type: string
               lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value can
-                  be detected.
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
                 type: string
               lastPlannedRevision:
-                description: LastPlannedRevision is the revision used by the last
-                  planning process. The result could be either no plan change or a
-                  new plan generated.
+                description: |-
+                  LastPlannedRevision is the revision used by the last planning process.
+                  The result could be either no plan change or a new plan generated.
                 type: string
               lock:
                 description: LockStatus defines the observed state of a Terraform
@@ -4990,14 +4776,19 @@ spec:
         description: Terraform is the Schema for the terraforms API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -5009,9 +4800,9 @@ spec:
                 description: Clean the runner pod up after each reconciliation cycle
                 type: boolean
               approvePlan:
-                description: ApprovePlan specifies name of a plan wanted to approve.
-                  If its value is "auto", the controller will automatically approve
-                  every plan.
+                description: |-
+                  ApprovePlan specifies name of a plan wanted to approve.
+                  If its value is "auto", the controller will automatically approve every plan.
                 type: string
               backendConfig:
                 description: BackendConfigSpec is for specifying configuration for
@@ -5050,16 +4841,17 @@ spec:
                       - ConfigMap
                       type: string
                     name:
-                      description: Name of the configs referent. Should reside in
-                        the same namespace as the referring resource.
+                      description: |-
+                        Name of the configs referent. Should reside in the same namespace as the
+                        referring resource.
                       maxLength: 253
                       minLength: 1
                       type: string
                     optional:
-                      description: Optional marks this BackendConfigsReference as
-                        optional. When set, a not found error for the values reference
-                        is ignored, but any Key or transient error will still result
-                        in a reconciliation failure.
+                      description: |-
+                        Optional marks this BackendConfigsReference as optional. When set, a not found error
+                        for the values reference is ignored, but any Key or
+                        transient error will still result in a reconciliation failure.
                       type: boolean
                   required:
                   - kind
@@ -5070,19 +4862,21 @@ spec:
                 description: BranchPlanner configuration.
                 properties:
                   enablePathScope:
-                    description: EnablePathScope specifies if the Branch Planner should
-                      or shouldn't check if a Pull Request has changes under `.spec.path`.
-                      If enabled extra resources will be created only if there are
-                      any changes in terraform files.
+                    description: |-
+                      EnablePathScope specifies if the Branch Planner should or shouldn't check
+                      if a Pull Request has changes under `.spec.path`. If enabled extra
+                      resources will be created only if there are any changes in terraform files.
                     type: boolean
                 type: object
               breakTheGlass:
-                description: BreakTheGlass specifies if the reconciliation should
-                  stop and allow interactive shell in case of emergency.
+                description: |-
+                  BreakTheGlass specifies if the reconciliation should stop
+                  and allow interactive shell in case of emergency.
                 type: boolean
               cliConfigSecretRef:
-                description: SecretReference represents a Secret Reference. It has
-                  enough information to retrieve secret in any namespace
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
                 properties:
                   name:
                     description: name is unique within a namespace to reference a
@@ -5117,8 +4911,9 @@ spec:
                 type: object
               dependsOn:
                 items:
-                  description: NamespacedObjectReference contains enough information
-                    to locate the referenced Kubernetes resource object in any namespace.
+                  description: |-
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
                   properties:
                     name:
                       description: Name of the referent.
@@ -5137,14 +4932,15 @@ spec:
                 type: boolean
               destroyResourcesOnDeletion:
                 default: false
-                description: Create destroy plan and apply it to destroy terraform
-                  resources upon deletion of this object. Defaults to false.
+                description: |-
+                  Create destroy plan and apply it to destroy terraform resources
+                  upon deletion of this object. Defaults to false.
                 type: boolean
               disableDriftDetection:
                 default: false
-                description: Disable automatic drift detection. Drift detection may
-                  be resource intensive in the context of a large cluster or complex
-                  Terraform statefile. Defaults to false.
+                description: |-
+                  Disable automatic drift detection. Drift detection may be resource intensive in
+                  the context of a large cluster or complex Terraform statefile. Defaults to false.
                 type: boolean
               enableInventory:
                 description: EnableInventory enables the object to store resource
@@ -5153,6 +4949,15 @@ spec:
               enterprise:
                 description: Enterprise is the enterprise configuration placeholder.
                 x-kubernetes-preserve-unknown-fields: true
+              execType:
+                description: |-
+                  ExecType specifies the type of executable used for the operations.
+                  It can be either 'terraform' or 'tofu'.
+                  If not specified, the default is set based on the global configuration.
+                enum:
+                - terraform
+                - tofu
+                type: string
               fileMappings:
                 description: List of all configuration files to be created in initialization.
                 items:
@@ -5189,19 +4994,22 @@ spec:
                 type: array
               force:
                 default: false
-                description: Force instructs the controller to unconditionally re-plan
-                  and re-apply TF resources. Defaults to false.
+                description: |-
+                  Force instructs the controller to unconditionally
+                  re-plan and re-apply TF resources. Defaults to false.
                 type: boolean
               healthChecks:
                 description: List of health checks to be performed.
                 items:
-                  description: HealthCheck contains configuration needed to perform
-                    a health check after terraform is applied.
+                  description: |-
+                    HealthCheck contains configuration needed to perform a health check after
+                    terraform is applied.
                   properties:
                     address:
-                      description: Address to perform tcp health check on. Required
-                        when tcp type is specified. Go template can be used to reference
-                        values from the terraform output (e.g. 127.0.0.1:8080, {{.address}}:{{.port}}).
+                      description: |-
+                        Address to perform tcp health check on. Required when tcp type is specified.
+                        Go template can be used to reference values from the terraform output
+                        (e.g. 127.0.0.1:8080, {{.address}}:{{.port}}).
                       type: string
                     name:
                       description: Name of the health check.
@@ -5210,23 +5018,25 @@ spec:
                       type: string
                     timeout:
                       default: 20s
-                      description: The timeout period at which the connection should
-                        timeout if unable to complete the request. When not specified,
-                        default 20s timeout is used.
+                      description: |-
+                        The timeout period at which the connection should timeout if unable to
+                        complete the request.
+                        When not specified, default 20s timeout is used.
                       type: string
                     type:
-                      description: Type of the health check, valid values are ('tcp',
-                        'http'). If tcp is specified, address is required. If http
-                        is specified, url is required.
+                      description: |-
+                        Type of the health check, valid values are ('tcp', 'http').
+                        If tcp is specified, address is required.
+                        If http is specified, url is required.
                       enum:
                       - tcp
                       - http
                       type: string
                     url:
-                      description: URL to perform http health check on. Required when
-                        http type is specified. Go template can be used to reference
-                        values from the terraform output (e.g. https://example.org,
-                        {{.output_url}}).
+                      description: |-
+                        URL to perform http health check on. Required when http type is specified.
+                        Go template can be used to reference values from the terraform output
+                        (e.g. https://example.org, {{.output_url}}).
                       type: string
                   required:
                   - name
@@ -5243,12 +5053,14 @@ spec:
                 format: int32
                 type: integer
               path:
-                description: Path to the directory containing Terraform (.tf) files.
+                description: |-
+                  Path to the directory containing Terraform (.tf) files.
                   Defaults to 'None', which translates to the root path of the SourceRef.
                 type: string
               planOnly:
-                description: PlanOnly specifies if the reconciliation should or should
-                  not stop at plan phase.
+                description: |-
+                  PlanOnly specifies if the reconciliation should or should not stop at plan
+                  phase.
                 type: boolean
               readInputsFromSecrets:
                 items:
@@ -5268,18 +5080,21 @@ spec:
                   the apply step.
                 type: boolean
               remediation:
-                description: Remediation specifies what the controller should do when
-                  reconciliation fails. The default is to not perform any action.
+                description: |-
+                  Remediation specifies what the controller should do when reconciliation
+                  fails. The default is to not perform any action.
                 properties:
                   retries:
-                    description: Retries is the number of retries that should be attempted
-                      on failures before bailing. Defaults to '0', a negative integer
-                      denotes unlimited retries.
+                    description: |-
+                      Retries is the number of retries that should be attempted on failures
+                      before bailing. Defaults to '0', a negative integer denotes unlimited
+                      retries.
                     format: int64
                     type: integer
                 type: object
               retryInterval:
-                description: The interval at which to retry a previously failed reconciliation.
+                description: |-
+                  The interval at which to retry a previously failed reconciliation.
                   The default value is 15 when not specified.
                 type: string
               runnerPodTemplate:
@@ -5307,23 +5122,20 @@ spec:
                               for the pod.
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node matches the corresponding matchExpressions;
-                                  the node(s) with the highest sum are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
-                                  description: An empty preferred scheduling term
-                                    matches all objects with implicit weight 0 (i.e.
-                                    it's a no-op). A null preferred scheduling term
-                                    matches no objects (i.e. is also a no-op).
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
                                     preference:
                                       description: A node selector term, associated
@@ -5333,32 +5145,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5371,32 +5177,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5419,53 +5219,46 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to an update), the system may or may not try
-                                  to eventually evict the pod from its node.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
                                       terms. The terms are ORed.
                                     items:
-                                      description: A null or empty node selector term
-                                        matches no objects. The requirements of them
-                                        are ANDed. The TopologySelectorTerm type implements
-                                        a subset of the NodeSelectorTerm.
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                       properties:
                                         matchExpressions:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5478,32 +5271,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5526,19 +5313,16 @@ spec:
                               other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -5557,10 +5341,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -5568,20 +5351,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -5593,36 +5372,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -5630,20 +5402,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -5655,46 +5423,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -5703,25 +5462,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to a pod label update), the system may or may
-                                  not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes
-                                  corresponding to each podAffinityTerm are intersected,
-                                  i.e. all terms must be satisfied.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -5732,30 +5488,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5767,53 +5518,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5825,34 +5568,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -5866,19 +5603,16 @@ spec:
                               etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the anti-affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity
-                                  expressions, etc.), compute a sum by iterating through
-                                  the elements of this field and adding "weight" to
-                                  the sum if the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -5897,10 +5631,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -5908,20 +5641,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -5933,36 +5662,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -5970,20 +5692,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -5995,46 +5713,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -6043,25 +5752,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the anti-affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  anti-affinity requirements specified by this field
-                                  cease to be met at some point during pod execution
-                                  (e.g. due to a pod label update), the system may
-                                  or may not try to eventually evict the pod from
-                                  its node. When there are multiple elements, the
-                                  lists of nodes corresponding to each podAffinityTerm
-                                  are intersected, i.e. all terms must be satisfied.
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -6072,30 +5778,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6107,53 +5808,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6165,34 +5858,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -6202,7 +5889,8 @@ spec:
                             type: object
                         type: object
                       env:
-                        description: List of environment variables to set in the container.
+                        description: |-
+                          List of environment variables to set in the container.
                           Cannot be updated.
                         items:
                           description: EnvVar represents an environment variable present
@@ -6213,16 +5901,16 @@ spec:
                                 be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables
-                                in the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. Double $$ are
-                                reduced to a single $, which allows for escaping the
-                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Defaults to "".'
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -6235,10 +5923,10 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -6249,11 +5937,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
                                       description: Version of the schema the FieldPath
@@ -6268,11 +5954,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -6302,10 +5986,10 @@ spec:
                                         from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -6321,13 +6005,13 @@ spec:
                           type: object
                         type: array
                       envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must
-                          be a C_IDENTIFIER. All invalid keys will be reported as
-                          an event when the container is starting. When a key exists
-                          in multiple sources, the value associated with the last
-                          source will take precedence. Values defined by an Env with
-                          a duplicate key will take precedence. Cannot be updated.
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -6336,9 +6020,10 @@ spec:
                               description: The ConfigMap to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must
@@ -6354,9 +6039,10 @@ spec:
                               description: The Secret to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be
@@ -6369,9 +6055,9 @@ spec:
                       hostAliases:
                         description: Set host aliases for the Runner Pod
                         items:
-                          description: HostAlias holds the mapping between IP and
-                            hostnames that will be injected as an entry in the pod's
-                            hosts file.
+                          description: |-
+                            HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                            pod's hosts file.
                           properties:
                             hostnames:
                               description: Hostnames for the above IP address.
@@ -6393,38 +6079,35 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The container
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The container image''s ENTRYPOINT is used
-                                if this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -6434,17 +6117,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -6457,10 +6139,10 @@ spec:
                                             description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -6471,11 +6153,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                         properties:
                                           apiVersion:
                                             description: Version of the schema the
@@ -6491,11 +6171,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -6527,10 +6205,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -6546,14 +6224,13 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -6562,10 +6239,10 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -6581,10 +6258,10 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -6595,44 +6272,42 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                This field is optional to allow higher level config
-                                management to default or override container images
-                                in workload controllers like Deployments and StatefulSets.'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
-                              description: Actions that the management system should
-                                take in response to container lifecycle events. Cannot
-                                be updated.
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -6642,8 +6317,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -6654,10 +6329,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -6675,24 +6349,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -6702,44 +6376,37 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -6749,8 +6416,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -6761,10 +6428,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -6782,24 +6448,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -6809,10 +6475,10 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -6820,30 +6486,29 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness.
-                                Container will be restarted if the probe fails. Cannot
-                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -6857,11 +6522,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -6871,9 +6537,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -6883,10 +6549,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -6903,34 +6568,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -6945,61 +6611,59 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL.
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
                                 Each container in a pod must have a unique name (DNS_LABEL).
                                 Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container.
-                                Not specifying a port here DOES NOT prevent that port
-                                from being exposed. Any port which is listening on
-                                the default "0.0.0.0" address inside a container will
-                                be accessible from the network. Modifying this array
-                                with strategic merge patch may corrupt the data. For
-                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                 Cannot be updated.
                               items:
                                 description: ContainerPort represents a network port
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -7007,23 +6671,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -7034,30 +6699,29 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness.
-                                Container will be removed from service endpoints if
-                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -7071,11 +6735,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -7085,9 +6750,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -7097,10 +6762,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -7117,34 +6781,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -7159,36 +6824,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -7199,14 +6861,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -7215,25 +6877,31 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -7249,8 +6917,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -7259,35 +6928,34 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             securityContext:
-                              description: 'SecurityContext defines the security options
-                                the container should be run with. If set, the fields
-                                of SecurityContext override the equivalent fields
-                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -7305,66 +6973,60 @@ spec:
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -7384,107 +7046,95 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must only be set if type is "Localhost".
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must only be set if type is "Localhost".
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        This field is alpha-level and will only be
-                                        honored by components that enable the WindowsHostProcessContainers
-                                        feature flag. Setting this field without the
-                                        feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be honored by components that enable the
+                                        WindowsHostProcessContainers feature flag. Setting this field without the feature
+                                        flag will result in errors when validating the Pod. All of a Pod's containers must
+                                        have the same effective HostProcess value (it is not allowed to have a mix of HostProcess
+                                        containers and non-HostProcess containers).  In addition, if HostProcess is true
+                                        then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has
-                                successfully initialized. If specified, no other probes
-                                are executed until this completes successfully. If
-                                this probe fails, the Pod will be restarted, just
-                                as if the livenessProbe failed. This can be used to
-                                provide different probe parameters at the beginning
-                                of a Pod''s lifecycle, when it might take a long time
-                                to load data or warm a cache, than during steady-state
-                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -7498,11 +7148,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -7512,9 +7163,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -7524,10 +7175,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -7544,34 +7194,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -7586,83 +7237,75 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -7687,44 +7330,44 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -7732,10 +7375,11 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
@@ -7753,18 +7397,23 @@ spec:
                         description: Set Resources for the Runner Pod container
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -7781,8 +7430,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7791,30 +7441,31 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       securityContext:
                         description: Set SecurityContext for the Runner Pod container
                         properties:
                           allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether
-                              a process can gain more privileges than its parent process.
-                              This bool directly controls if the no_new_privs flag
-                              will be set on the container process. AllowPrivilegeEscalation
-                              is true always when the container is: 1) run as Privileged
-                              2) has CAP_SYS_ADMIN Note that this field cannot be
-                              set when spec.os.name is windows.'
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running
-                              containers. Defaults to the default set of capabilities
-                              granted by the container runtime. Note that this field
-                              cannot be set when spec.os.name is windows.
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
                                 description: Added capabilities
@@ -7832,61 +7483,60 @@ spec:
                                 type: array
                             type: object
                           privileged:
-                            description: Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent
-                              to root on the host. Defaults to false. Note that this
-                              field cannot be set when spec.os.name is windows.
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
-                            description: procMount denotes the type of proc mount
-                              to use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root
-                              filesystem. Default is false. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set
-                              when spec.os.name is windows.
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description: Indicates that the container must run as
-                              a non-root user. If true, the Kubelet will validate
-                              the image at runtime to ensure that it does not run
-                              as UID 0 (root) and fail to start the container if it
-                              does. If unset or false, no such validation will be
-                              performed. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                              Note that this field cannot be set when spec.os.name
-                              is windows.
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to the
-                              container. If unspecified, the container runtime will
-                              allocate a random SELinux context for each container.  May
-                              also be set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set
-                              when spec.os.name is windows.
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -7906,111 +7556,104 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by this container.
-                              If seccomp options are provided at both the pod & container
-                              level, the container options override the pod options.
-                              Note that this field cannot be set when spec.os.name
-                              is windows.
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
-                                description: localhostProfile indicates a profile
-                                  defined in a file on the node should be used. The
-                                  profile must be preconfigured on the node to work.
-                                  Must be a descending path, relative to the kubelet's
-                                  configured seccomp profile location. Must only be
-                                  set if type is "Localhost".
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must only be set if type is "Localhost".
                                 type: string
                               type:
-                                description: "type indicates which kind of seccomp
-                                  profile will be applied. Valid options are: \n Localhost
-                                  - a profile defined in a file on the node should
-                                  be used. RuntimeDefault - the container runtime
-                                  default profile should be used. Unconfined - no
-                                  profile should be applied."
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                             - type
                             type: object
                           windowsOptions:
-                            description: The Windows specific settings applied to
-                              all containers. If unspecified, the options from the
-                              PodSecurityContext will be used. If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set
-                              when spec.os.name is linux.
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA
-                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec
-                                  named by the GMSACredentialSpecName field.
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of
                                   the GMSA credential spec to use.
                                 type: string
                               hostProcess:
-                                description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container. This
-                                  field is alpha-level and will only be honored by
-                                  components that enable the WindowsHostProcessContainers
-                                  feature flag. Setting this field without the feature
-                                  flag will result in errors when validating the Pod.
-                                  All of a Pod's containers must have the same effective
-                                  HostProcess value (it is not allowed to have a mix
-                                  of HostProcess containers and non-HostProcess containers).  In
-                                  addition, if HostProcess is true then HostNetwork
-                                  must also be set to true.
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  This field is alpha-level and will only be honored by components that enable the
+                                  WindowsHostProcessContainers feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod. All of a Pod's containers must
+                                  have the same effective HostProcess value (it is not allowed to have a mix of HostProcess
+                                  containers and non-HostProcess containers).  In addition, if HostProcess is true
+                                  then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       tolerations:
                         description: Set the Tolerations for the Runner Pod
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -8021,34 +7664,36 @@ spec:
                             within a container.
                           properties:
                             mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
                               type: string
                             name:
                               description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                           - mountPath
@@ -8062,37 +7707,36 @@ spec:
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'awsElasticBlockStore represents an AWS
-                                Disk resource that is attached to a kubelet''s host
-                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly value true will force the
-                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: 'volumeID is unique ID of the persistent
-                                    disk resource in AWS (Amazon EBS volume). More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
@@ -8114,10 +7758,10 @@ spec:
                                     the blob storage
                                   type: string
                                 fsType:
-                                  description: fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
                                   description: 'kind expected values are Shared: multiple
@@ -8127,9 +7771,9 @@ spec:
                                     set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
@@ -8140,9 +7784,9 @@ spec:
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
                                   description: secretName is the  name of secret that
@@ -8160,8 +7804,9 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'monitors is Required: Monitors is
-                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
@@ -8171,67 +7816,72 @@ spec:
                                     is /'
                                   type: string
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: 'secretFile is Optional: SecretFile
-                                    is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: 'secretRef is Optional: SecretRef is
-                                    reference to the authentication secret for User,
-                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is optional: User is the rados
-                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'cinder represents a cinder volume attached
-                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Examples: "ext4", "xfs", "ntfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: 'readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is optional: points to a
-                                    secret object containing parameters used to connect
-                                    to OpenStack.'
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: 'volumeID used to identify the volume
-                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
@@ -8241,30 +7891,25 @@ spec:
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items if unspecified, each key-value
-                                    pair in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -8273,25 +7918,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -8299,9 +7940,10 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: optional specify whether the ConfigMap
@@ -8315,45 +7957,43 @@ spec:
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: driver is the name of the CSI driver
-                                    that handles this volume. Consult with your admin
-                                    for the correct name as registered in the cluster.
+                                  description: |-
+                                    driver is the name of the CSI driver that handles this volume.
+                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: fsType to mount. Ex. "ext4", "xfs",
-                                    "ntfs". If not provided, the empty value is passed
-                                    to the associated CSI driver which will determine
-                                    the default filesystem to apply.
+                                  description: |-
+                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated CSI driver
+                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: nodePublishSecretRef is a reference
-                                    to the secret object containing sensitive information
-                                    to pass to the CSI driver to complete the CSI
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no
-                                    secret is required. If the secret object contains
-                                    more than one secret, all secret references are
-                                    passed.
+                                    This field is optional, and  may be empty if no secret is required. If the
+                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: readOnly specifies a read-only configuration
-                                    for the volume. Defaults to false (read/write).
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: volumeAttributes stores driver-specific
-                                    properties that are passed to the CSI driver.
-                                    Consult your driver's documentation for supported
-                                    values.
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
@@ -8363,17 +8003,15 @@ spec:
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits to use on created
-                                    files by default. Must be a Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    Optional: mode bits to use on created files by default. Must be a
+                                    Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
@@ -8403,16 +8041,13 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file, must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
@@ -8423,10 +8058,9 @@ spec:
                                           the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -8454,121 +8088,125 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'emptyDir represents a temporary directory
-                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: 'medium represents what type of storage
-                                    medium should back this directory. The default
-                                    is "" which means to use the node''s default medium.
-                                    Must be an empty string (default) or Memory. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    medium represents what type of storage medium should back this directory.
+                                    The default is "" which means to use the node's default medium.
+                                    Must be an empty string (default) or Memory.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'sizeLimit is the total amount of local
-                                    storage required for this EmptyDir volume. The
-                                    size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would
-                                    be the minimum value between the SizeLimit specified
-                                    here and the sum of memory limits of all containers
-                                    in a pod. The default is nil which means that
-                                    the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                    The size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would be the minimum value between
+                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                    The default is nil which means that the limit is undefined.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "ephemeral represents a volume that is
-                                handled by a cluster storage driver. The volume's
-                                lifecycle is tied to the pod that defines it - it
-                                will be created before the pod starts, and deleted
-                                when the pod is removed. \n Use this if: a) the volume
-                                is only needed while the pod runs, b) features of
-                                normal volumes like restoring from snapshot or capacity
-                                tracking are needed, c) the storage driver is specified
-                                through a storage class, and d) the storage driver
-                                supports dynamic volume provisioning through a PersistentVolumeClaim
-                                (see EphemeralVolumeSource for more information on
-                                the connection between this volume type and PersistentVolumeClaim).
-                                \n Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the
-                                lifecycle of an individual pod. \n Use CSI for light-weight
-                                local ephemeral volumes if the CSI driver is meant
-                                to be used that way - see the documentation of the
-                                driver for more information. \n A pod can use both
-                                types of ephemeral volumes and persistent volumes
-                                at the same time."
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver.
+                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                and deleted when the pod is removed.
+
+
+                                Use this if:
+                                a) the volume is only needed while the pod runs,
+                                b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and
+                                d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+
+                                Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the lifecycle
+                                of an individual pod.
+
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                be used that way - see the documentation of the driver for
+                                more information.
+
+
+                                A pod can use both types of ephemeral volumes and
+                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: "Will be used to create a stand-alone
-                                    PVC to provision the volume. The pod in which
-                                    this EphemeralVolumeSource is embedded will be
-                                    the owner of the PVC, i.e. the PVC will be deleted
-                                    together with the pod.  The name of the PVC will
-                                    be `<pod name>-<volume name>` where `<volume name>`
-                                    is the name from the `PodSpec.Volumes` array entry.
-                                    Pod validation will reject the pod if the concatenated
-                                    name is not valid for a PVC (for example, too
-                                    long). \n An existing PVC with that name that
-                                    is not owned by the pod will *not* be used for
-                                    the pod to avoid using an unrelated volume by
-                                    mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created
-                                    PVC is meant to be used by the pod, the PVC has
-                                    to updated with an owner reference to the pod
-                                    once the pod exists. Normally this should not
-                                    be necessary, but it may be useful when manually
-                                    reconstructing a broken cluster. \n This field
-                                    is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created. \n Required,
-                                    must not be nil."
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume.
+                                    The pod in which this EphemeralVolumeSource is embedded will be the
+                                    owner of the PVC, i.e. the PVC will be deleted together with the
+                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                    `<volume name>` is the name from the `PodSpec.Volumes` array
+                                    entry. Pod validation will reject the pod if the concatenated name
+                                    is not valid for a PVC (for example, too long).
+
+
+                                    An existing PVC with that name that is not owned by the pod
+                                    will *not* be used for the pod to avoid using an unrelated
+                                    volume by mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created PVC is
+                                    meant to be used by the pod, the PVC has to updated with an
+                                    owner reference to the pod once the pod exists. Normally
+                                    this should not be necessary, but it may be useful when
+                                    manually reconstructing a broken cluster.
+
+
+                                    This field is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created.
+
+
+                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: May contain labels and annotations
-                                        that will be copied into the PVC when creating
-                                        it. No other fields are allowed and will be
-                                        rejected during validation.
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it. No other fields are allowed and will be rejected during
+                                        validation.
                                       type: object
                                     spec:
-                                      description: The specification for the PersistentVolumeClaim.
-                                        The entire content is copied unchanged into
-                                        the PVC that gets created from this template.
-                                        The same fields as in a PersistentVolumeClaim
+                                      description: |-
+                                        The specification for the PersistentVolumeClaim. The entire content is
+                                        copied unchanged into the PVC that gets created from this
+                                        template. The same fields as in a PersistentVolumeClaim
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'accessModes contains the desired
-                                            access modes the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'dataSource field can be used
-                                            to specify either: * An existing VolumeSnapshot
-                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller
-                                            can support the specified data source,
-                                            it will create a new volume based on the
-                                            contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate
-                                            is enabled, dataSource contents will be
-                                            copied to dataSourceRef, and dataSourceRef
-                                            contents will be copied to dataSource
-                                            when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef
-                                            will not be copied to dataSource.'
+                                            If the provisioner or an external controller can support the specified data source,
+                                            it will create a new volume based on the contents of the specified data source.
+                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -8584,50 +8222,36 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: 'dataSourceRef specifies the
-                                            object from which to populate the volume
-                                            with data, if a non-empty volume is desired.
-                                            This may be any object from a non-empty
-                                            API group (non core object) or a PersistentVolumeClaim
-                                            object. When this field is specified,
-                                            volume binding will only succeed if the
-                                            type of the specified object matches some
-                                            installed volume populator or dynamic
-                                            provisioner. This field will replace the
-                                            functionality of the dataSource field
-                                            and as such if both fields are non-empty,
-                                            they must have the same value. For backwards
-                                            compatibility, when namespace isn''t specified
-                                            in dataSourceRef, both fields (dataSource
-                                            and dataSourceRef) will be set to the
-                                            same value automatically if one of them
-                                            is empty and the other is non-empty. When
-                                            namespace is specified in dataSourceRef,
-                                            dataSource isn''t set to the same value
-                                            and must be empty. There are three important
-                                            differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific
-                                            types of objects, dataSourceRef allows
-                                            any non-core object, as well as PersistentVolumeClaim
-                                            objects. * While dataSource ignores disallowed
-                                            values (dropping them), dataSourceRef
-                                            preserves all values, and generates an
-                                            error if a disallowed value is specified.
-                                            * While dataSource only allows local objects,
-                                            dataSourceRef allows objects in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource
-                                            feature gate to be enabled. (Alpha) Using
-                                            the namespace field of dataSourceRef requires
-                                            the CrossNamespaceVolumeDataSource feature
-                                            gate to be enabled.'
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired. This may be any object from a non-empty API group (non
+                                            core object) or a PersistentVolumeClaim object.
+                                            When this field is specified, volume binding will only succeed if the type of
+                                            the specified object matches some installed volume populator or dynamic
+                                            provisioner.
+                                            This field will replace the functionality of the dataSource field and as such
+                                            if both fields are non-empty, they must have the same value. For backwards
+                                            compatibility, when namespace isn't specified in dataSourceRef,
+                                            both fields (dataSource and dataSourceRef) will be set to the same
+                                            value automatically if one of them is empty and the other is non-empty.
+                                            When namespace is specified in dataSourceRef,
+                                            dataSource isn't set to the same value and must be empty.
+                                            There are three important differences between dataSource and dataSourceRef:
+                                            * While dataSource only allows two specific types of objects, dataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            * While dataSource only allows local objects, dataSourceRef allows objects
+                                              in any namespaces.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -8638,50 +8262,43 @@ spec:
                                                 being referenced
                                               type: string
                                             namespace:
-                                              description: Namespace is the namespace
-                                                of resource being referenced Note
-                                                that when a namespace is specified,
-                                                a gateway.networking.k8s.io/ReferenceGrant
-                                                object is required in the referent
-                                                namespace to allow that namespace's
-                                                owner to accept the reference. See
-                                                the ReferenceGrant documentation for
-                                                details. (Alpha) This field requires
-                                                the CrossNamespaceVolumeDataSource
-                                                feature gate to be enabled.
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: 'resources represents the minimum
-                                            resources the volume should have. If RecoverVolumeExpansionFailure
-                                            feature is enabled users are allowed to
-                                            specify resource requirements that are
-                                            lower than previous value but must still
-                                            be higher than capacity recorded in the
-                                            status field of the claim. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: |-
+                                            resources represents the minimum resources the volume should have.
+                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            that are lower than previous value but must still be higher than capacity recorded in the
+                                            status field of the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             claims:
-                                              description: "Claims lists the names
-                                                of resources, defined in spec.resourceClaims,
-                                                that are used by this container. \n
-                                                This is an alpha field and requires
-                                                enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable.
-                                                It can only be set for containers."
+                                              description: |-
+                                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                                that are used by this container.
+
+
+                                                This is an alpha field and requires enabling the
+                                                DynamicResourceAllocation feature gate.
+
+
+                                                This field is immutable. It can only be set for containers.
                                               items:
                                                 description: ResourceClaim references
                                                   one entry in PodSpec.ResourceClaims.
                                                 properties:
                                                   name:
-                                                    description: Name must match the
-                                                      name of one entry in pod.spec.resourceClaims
-                                                      of the Pod where this field
-                                                      is used. It makes that resource
-                                                      available inside a container.
+                                                    description: |-
+                                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                                      the Pod where this field is used. It makes that resource available
+                                                      inside a container.
                                                     type: string
                                                 required:
                                                 - name
@@ -8697,9 +8314,9 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Limits describes the maximum
-                                                amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -8708,14 +8325,11 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Requests describes the
-                                                minimum amount of compute resources
-                                                required. If Requests is omitted for
-                                                a container, it defaults to Limits
-                                                if that is explicitly specified, otherwise
-                                                to an implementation-defined value.
-                                                Requests cannot exceed Limits. More
-                                                info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Requests describes the minimum amount of compute resources required.
+                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
@@ -8727,10 +8341,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -8738,20 +8351,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -8763,27 +8372,22 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: 'storageClassName is the name
-                                            of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeMode:
-                                          description: volumeMode defines what type
-                                            of volume is required by the claim. Value
-                                            of Filesystem is implied when not included
-                                            in claim spec.
+                                          description: |-
+                                            volumeMode defines what type of volume is required by the claim.
+                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
                                           description: volumeName is the binding reference
@@ -8800,21 +8404,20 @@ spec:
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. TODO: how
-                                    do we prevent errors in the filesystem from compromising
-                                    the machine'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
                                   description: 'targetWWNs is Optional: FC target
@@ -8823,28 +8426,27 @@ spec:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'wwids Optional: FC volume world wide
-                                    identifiers (wwids) Either wwids or combination
-                                    of targetWWNs and lun must be set, but not both
-                                    simultaneously.'
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: flexVolume represents a generic volume
-                                resource that is provisioned/attached using an exec
-                                based plugin.
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
                                   description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". The
-                                    default filesystem depends on FlexVolume script.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
@@ -8853,23 +8455,23 @@ spec:
                                     extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'readOnly is Optional: defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is Optional: secretRef is
-                                    reference to the secret object containing sensitive
-                                    information to pass to the plugin scripts. This
-                                    may be empty if no secret object is specified.
-                                    If the secret object contains more than one secret,
-                                    all secrets are passed to the plugin scripts.'
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugin scripts. This may be
+                                    empty if no secret object is specified. If the secret object
+                                    contains more than one secret, all secrets are passed to the plugin
+                                    scripts.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -8882,9 +8484,9 @@ spec:
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: datasetName is Name of the dataset
-                                    stored as metadata -> name on the dataset for
-                                    Flocker should be considered as deprecated
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -8892,57 +8494,55 @@ spec:
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'gcePersistentDisk represents a GCE Disk
-                                resource that is attached to a kubelet''s host machine
-                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: 'fsType is filesystem type of the volume
-                                    that you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'pdName is unique name of the PD resource
-                                    in GCE. Used to identify the disk in GCE. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'gitRepo represents a git repository at
-                                a particular revision. DEPRECATED: GitRepo is deprecated.
-                                To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo
-                                using git, then mount the EmptyDir into the Pod''s
-                                container.'
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is
-                                    supplied, the volume directory will be the git
-                                    repository.  Otherwise, if specified, the volume
-                                    will contain the git repository in the subdirectory
-                                    with the given name.
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                    the subdirectory with the given name.
                                   type: string
                                 repository:
                                   description: repository is the URL
@@ -8955,54 +8555,61 @@ spec:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'glusterfs represents a Glusterfs mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: 'endpoints is the endpoint name that
-                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: 'path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the Glusterfs
-                                    volume to be mounted with read-only permissions.
-                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'hostPath represents a pre-existing file
-                                or directory on the host machine that is directly
-                                exposed to the container. This is generally used for
-                                system agents or other privileged things that are
-                                allowed to see the host machine. Most containers will
-                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                --- TODO(jonesdl) We need to restrict who can use
-                                host directory mounts and who can/can not mount host
-                                directories as read/write.'
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container. This is generally
+                                used for system agents or other privileged things that are allowed
+                                to see the host machine. Most containers will NOT need this.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                ---
+                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: 'path of the directory on the host.
-                                    If the path is a symlink, it will follow the link
-                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: 'type for HostPath Volume Defaults
-                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'iscsi represents an ISCSI Disk resource
-                                that is attached to a kubelet''s host machine and
-                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -9013,62 +8620,59 @@ spec:
                                     iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: initiatorName is the custom iSCSI Initiator
-                                    Name. If initiatorName is specified with iscsiInterface
-                                    simultaneously, new iSCSI interface <target portal>:<volume
-                                    name> will be created for the connection.
+                                  description: |-
+                                    initiatorName is the custom iSCSI Initiator Name.
+                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
                                   description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iscsiInterface is the interface Name
-                                    that uses an iSCSI transport. Defaults to 'default'
-                                    (tcp).
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: portals is the iSCSI Target Portal
-                                    List. The portal is either an IP or ip_addr:port
-                                    if the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false.
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
                                   type: boolean
                                 secretRef:
                                   description: secretRef is the CHAP Secret for iSCSI
                                     target and initiator authentication
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: targetPortal is iSCSI Target Portal.
-                                    The Portal is either an IP or ip_addr:port if
-                                    the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -9076,43 +8680,51 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'name of the volume. Must be a DNS_LABEL
-                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             nfs:
-                              description: 'nfs represents an NFS mount on the host
-                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: 'path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the NFS export
-                                    to be mounted with read-only permissions. Defaults
-                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: 'server is the hostname or IP address
-                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'persistentVolumeClaimVolumeSource represents
-                                a reference to a PersistentVolumeClaim in the same
-                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: 'claimName is the name of a PersistentVolumeClaim
-                                    in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: readOnly Will force the ReadOnly setting
-                                    in VolumeMounts. Default false.
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
                                   type: boolean
                               required:
                               - claimName
@@ -9123,10 +8735,10 @@ spec:
                                 machine
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
                                   description: pdID is the ID that identifies Photon
@@ -9140,15 +8752,15 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fSType represents the filesystem type
-                                    to mount Must be a filesystem type supported by
-                                    the host operating system. Ex. "ext4", "xfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
                                   description: volumeID uniquely identifies a Portworx
@@ -9162,16 +8774,13 @@ spec:
                                 secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: defaultMode are the mode bits used
-                                    to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Directories within the path
-                                    are not affected by this setting. This might be
-                                    in conflict with other options that affect the
-                                    file mode, like fsGroup, and the result can be
-                                    other mode bits set.
+                                  description: |-
+                                    defaultMode are the mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
@@ -9185,19 +8794,14 @@ spec:
                                           configMap data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced ConfigMap will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the ConfigMap, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the ConfigMap,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -9206,29 +8810,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -9236,10 +8832,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional specify whether
@@ -9280,20 +8876,13 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file, must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -9306,12 +8895,9 @@ spec:
                                                     start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: 'Selects a resource
-                                                    of the container: only resources
-                                                    limits and requests (limits.cpu,
-                                                    limits.memory, requests.cpu and
-                                                    requests.memory) are currently
-                                                    supported.'
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
                                                       description: 'Container name:
@@ -9345,19 +8931,14 @@ spec:
                                           secret data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced Secret will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the Secret, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the Secret,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -9366,29 +8947,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -9396,10 +8969,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional field specify whether
@@ -9412,32 +8985,26 @@ spec:
                                           about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: audience is the intended
-                                              audience of the token. A recipient of
-                                              a token must identify itself with an
-                                              identifier specified in the audience
-                                              of the token, and otherwise should reject
-                                              the token. The audience defaults to
-                                              the identifier of the apiserver.
+                                            description: |-
+                                              audience is the intended audience of the token. A recipient of a token
+                                              must identify itself with an identifier specified in the audience of the
+                                              token, and otherwise should reject the token. The audience defaults to the
+                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: expirationSeconds is the
-                                              requested duration of validity of the
-                                              service account token. As the token
-                                              approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service
-                                              account token. The kubelet will start
-                                              trying to rotate the token if the token
-                                              is older than 80 percent of its time
-                                              to live or if the token is older than
-                                              24 hours.Defaults to 1 hour and must
-                                              be at least 10 minutes.
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token. As the token approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service account token. The kubelet will
+                                              start trying to rotate the token if the token is older than 80 percent of
+                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: path is the path relative
-                                              to the mount point of the file to project
-                                              the token into.
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -9450,29 +9017,30 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: group to map volume access to Default
-                                    is no group
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: readOnly here will force the Quobyte
-                                    volume to be mounted with read-only permissions.
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: registry represents a single or multiple
-                                    Quobyte Registry services specified as a string
-                                    as host:port pair (multiple entries are separated
-                                    with commas) which acts as the central registry
-                                    for volumes
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple entries are separated with commas)
+                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: tenant owning the given Quobyte volume
-                                    in the Backend Used with dynamically provisioned
-                                    Quobyte volumes, value is set by the plugin
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: user to map volume access to Defaults
-                                    to serivceaccount user
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
                                   description: volume is a string that references
@@ -9483,60 +9051,68 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'rbd represents a Rados Block Device mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md'
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: 'image is the rados image name. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: 'keyring is the path to key ring for
-                                    RBDUser. Default is /etc/ceph/keyring. More info:
-                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: 'monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'pool is the rados pool name. Default
-                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is name of the authentication
-                                    secret for RBDUser. If provided overrides keyring.
-                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is the rados user name. Default
-                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
@@ -9547,10 +9123,11 @@ spec:
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
-                                    is "xfs".
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs".
+                                    Default is "xfs".
                                   type: string
                                 gateway:
                                   description: gateway is the host address of the
@@ -9561,21 +9138,20 @@ spec:
                                     ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef references to the secret
-                                    for ScaleIO user and other sensitive information.
-                                    If this is not provided, Login operation will
-                                    fail.
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -9584,8 +9160,8 @@ spec:
                                     communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: storageMode indicates whether the storage
-                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                  description: |-
+                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
@@ -9597,9 +9173,9 @@ spec:
                                     as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the name of a volume
-                                    already created in the ScaleIO system that is
-                                    associated with this volume source.
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -9607,34 +9183,30 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'secret represents a secret that should
-                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items If unspecified, each key-value
-                                    pair in the Data field of the referenced Secret
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -9643,25 +9215,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -9673,8 +9241,9 @@ spec:
                                     Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'secretName is the name of the secret
-                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
@@ -9682,44 +9251,42 @@ spec:
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef specifies the secret to use
-                                    for obtaining the StorageOS API credentials.  If
-                                    not specified, default values will be attempted.
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: volumeName is the human-readable name
-                                    of the StorageOS volume.  Volume names are only
-                                    unique within a namespace.
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: volumeNamespace specifies the scope
-                                    of the volume within StorageOS.  If no namespace
-                                    is specified then the Pod's namespace will be
-                                    used.  This allows the Kubernetes name scoping
-                                    to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default
-                                    behaviour. Set to "default" if you are not using
-                                    namespaces within StorageOS. Namespaces that do
-                                    not pre-exist within StorageOS will be created.
+                                  description: |-
+                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                    namespace is specified then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default behaviour.
+                                    Set to "default" if you are not using namespaces within StorageOS.
+                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
@@ -9727,10 +9294,10 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
                                   description: storagePolicyID is the storage Policy
@@ -9756,16 +9323,17 @@ spec:
                 type: object
               runnerTerminationGracePeriodSeconds:
                 default: 30
-                description: Configure the termination grace period for the runner
-                  pod. Use this parameter to allow the Terraform process to gracefully
-                  shutdown. Consider increasing for large, complex or slow-moving
-                  Terraform managed resources.
+                description: |-
+                  Configure the termination grace period for the runner pod. Use this parameter
+                  to allow the Terraform process to gracefully shutdown. Consider increasing for
+                  large, complex or slow-moving Terraform managed resources.
                 format: int64
                 type: integer
               serviceAccountName:
                 default: tf-runner
-                description: Name of a ServiceAccount for the runner Pod to provision
-                  Terraform resources. Default to tf-runner.
+                description: |-
+                  Name of a ServiceAccount for the runner Pod to provision Terraform resources.
+                  Default to tf-runner.
                 type: string
               sourceRef:
                 description: SourceRef is the reference of the source where the Terraform
@@ -9802,9 +9370,9 @@ spec:
                 - human
                 type: string
               suspend:
-                description: Suspend is to tell the controller to suspend subsequent
-                  TF executions, it does not apply to already started executions.
-                  Defaults to false.
+                description: |-
+                  Suspend is to tell the controller to suspend subsequent TF executions,
+                  it does not apply to already started executions. Defaults to false.
                 type: boolean
               targets:
                 description: Targets specify the resource, module or collection of
@@ -9823,43 +9391,56 @@ spec:
                 properties:
                   forceUnlock:
                     default: "no"
-                    description: "ForceUnlock a Terraform state if it has become locked
-                      for any reason. Defaults to `no`. \n This is an Enum and has
-                      the expected values of: \n - auto - yes - no \n WARNING: Only
-                      use `auto` in the cases where you are absolutely certain that
-                      no other system is using this state, you could otherwise end
-                      up in a bad place See https://www.terraform.io/language/state/locking#force-unlock
-                      for more information on the terraform state lock and force unlock."
+                    description: |-
+                      ForceUnlock a Terraform state if it has become locked for any reason. Defaults to `no`.
+
+
+                      This is an Enum and has the expected values of:
+
+
+                      - auto
+                      - yes
+                      - no
+
+
+                      WARNING: Only use `auto` in the cases where you are absolutely certain that
+                      no other system is using this state, you could otherwise end up in a bad place
+                      See https://www.terraform.io/language/state/locking#force-unlock for more
+                      information on the terraform state lock and force unlock.
                     enum:
                     - "yes"
                     - "no"
                     - auto
                     type: string
                   lockIdentifier:
-                    description: "LockIdentifier holds the Identifier required by
-                      Terraform to unlock the state if it ever gets into a locked
-                      state. \n You'll need to put the Lock Identifier in here while
-                      setting ForceUnlock to either `yes` or `auto`. \n Leave this
-                      empty to do nothing, set this to the value of the `Lock Info:
-                      ID: [value]`, e.g. `f2ab685b-f84d-ac0b-a125-378a22877e8d`, to
-                      force unlock the state."
+                    description: |-
+                      LockIdentifier holds the Identifier required by Terraform to unlock the state
+                      if it ever gets into a locked state.
+
+
+                      You'll need to put the Lock Identifier in here while setting ForceUnlock to
+                      either `yes` or `auto`.
+
+
+                      Leave this empty to do nothing, set this to the value of the `Lock Info: ID: [value]`,
+                      e.g. `f2ab685b-f84d-ac0b-a125-378a22877e8d`, to force unlock the state.
                     type: string
                   lockTimeout:
                     default: 0s
-                    description: "LockTimeout is a Duration string that instructs
-                      Terraform to retry acquiring a lock for the specified period
-                      of time before returning an error. The duration syntax is a
-                      number followed by a time unit letter, such as `3s` for three
-                      seconds. \n Defaults to `0s` which will behave as though `LockTimeout`
-                      was not set"
+                    description: |-
+                      LockTimeout is a Duration string that instructs Terraform to retry acquiring a lock for the specified period of
+                      time before returning an error. The duration syntax is a number followed by a time unit letter, such as `3s` for
+                      three seconds.
+
+
+                      Defaults to `0s` which will behave as though `LockTimeout` was not set
                     type: string
                 type: object
               values:
-                description: Values map to the Terraform variable "values", which
-                  is an object of arbitrary values. It is a convenient way to pass
-                  values to Terraform resources without having to define a variable
-                  for each value. To use this feature, your Terraform file must define
-                  the variable "values".
+                description: |-
+                  Values map to the Terraform variable "values", which is an object of arbitrary values.
+                  It is a convenient way to pass values to Terraform resources without having to define
+                  a variable for each value. To use this feature, your Terraform file must define the variable "values".
                 x-kubernetes-preserve-unknown-fields: true
               vars:
                 description: List of input variables to set for the Terraform program.
@@ -9881,8 +9462,10 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -9893,10 +9476,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
-                          description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
                               description: Version of the schema the FieldPath is
@@ -9911,10 +9493,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
-                          description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
                               description: 'Container name: required for volumes,
@@ -9943,8 +9524,10 @@ spec:
                                 be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must
@@ -9960,14 +9543,14 @@ spec:
                   type: object
                 type: array
               varsFrom:
-                description: List of references to a Secret or a ConfigMap to generate
-                  variables for Terraform resources based on its data, selectively
-                  by varsKey. Values of the later Secret / ConfigMap with the same
-                  keys will override those of the former.
+                description: |-
+                  List of references to a Secret or a ConfigMap to generate variables for
+                  Terraform resources based on its data, selectively by varsKey. Values of the later
+                  Secret / ConfigMap with the same keys will override those of the former.
                 items:
-                  description: VarsReference contain a reference of a Secret or a
-                    ConfigMap to generate variables for Terraform resources based
-                    on its data, selectively by varsKey.
+                  description: |-
+                    VarsReference contain a reference of a Secret or a ConfigMap to generate
+                    variables for Terraform resources based on its data, selectively by varsKey.
                   properties:
                     kind:
                       description: Kind of the values referent, valid values are ('Secret',
@@ -9977,16 +9560,17 @@ spec:
                       - ConfigMap
                       type: string
                     name:
-                      description: Name of the values referent. Should reside in the
-                        same namespace as the referring resource.
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
                       maxLength: 253
                       minLength: 1
                       type: string
                     optional:
-                      description: Optional marks this VarsReference as optional.
-                        When set, a not found error for the values reference is ignored,
-                        but any VarsKey or transient error will still result in a
-                        reconciliation failure.
+                      description: |-
+                        Optional marks this VarsReference as optional. When set, a not found error
+                        for the values reference is ignored, but any VarsKey or
+                        transient error will still result in a reconciliation failure.
                       type: boolean
                     varsKeys:
                       description: VarsKeys is the data key at which a specific value
@@ -10045,9 +9629,9 @@ spec:
                     description: Name is the name of the Secret to be written
                     type: string
                   outputs:
-                    description: Outputs contain the selected names of outputs to
-                      be written to the secret. Empty array means writing all outputs,
-                      which is default.
+                    description: |-
+                      Outputs contain the selected names of outputs to be written
+                      to the secret. Empty array means writing all outputs, which is default.
                     items:
                       type: string
                     type: array
@@ -10070,42 +9654,42 @@ spec:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -10119,11 +9703,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -10165,13 +9750,15 @@ spec:
                 - entries
                 type: object
               lastAppliedByDriftDetectionAt:
-                description: LastAppliedByDriftDetectionAt is the time when the last
-                  drift was detected and terraform apply was performed as a result
+                description: |-
+                  LastAppliedByDriftDetectionAt is the time when the last drift was detected and
+                  terraform apply was performed as a result
                 format: date-time
                 type: string
               lastAppliedRevision:
-                description: The last successfully applied revision. The revision
-                  format for Git sources is <branch|tag>/<commit-sha>.
+                description: |-
+                  The last successfully applied revision.
+                  The revision format for Git sources is <branch|tag>/<commit-sha>.
                 type: string
               lastAttemptedRevision:
                 description: LastAttemptedRevision is the revision of the last reconciliation
@@ -10183,9 +9770,10 @@ spec:
                 format: date-time
                 type: string
               lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value can
-                  be detected.
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
                 type: string
               lastPlanAt:
                 description: LastPlanAt is the time when the last terraform plan was
@@ -10193,9 +9781,9 @@ spec:
                 format: date-time
                 type: string
               lastPlannedRevision:
-                description: LastPlannedRevision is the revision used by the last
-                  planning process. The result could be either no plan change or a
-                  new plan generated.
+                description: |-
+                  LastPlannedRevision is the revision used by the last planning process.
+                  The result could be either no plan change or a new plan generated.
                 type: string
               lock:
                 description: LockStatus defines the observed state of a Terraform
@@ -10224,7 +9812,8 @@ spec:
                     type: string
                 type: object
               reconciliationFailures:
-                description: ReconciliationFailures is the number of reconciliation
+                description: |-
+                  ReconciliationFailures is the number of reconciliation
                   failures since the last success or update.
                 format: int64
                 type: integer

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -187,6 +187,7 @@ func TestMain(m *testing.M) {
 		RunnerCreationTimeout:     120 * time.Second,
 		RunnerGRPCMaxMessageSize:  4,
 		UsePodSubdomainResolution: false,
+		ExecPath:                  "terraform",
 	}
 
 	// We use 1 concurrent and 10s httpRetry in the test

--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -82,6 +82,7 @@ type TerraformReconciler struct {
 	ClusterDomain             string
 	NoCrossNamespaceRefs      bool
 	UsePodSubdomainResolution bool
+	ExecPath                  string
 }
 
 //+kubebuilder:rbac:groups=infra.contrib.fluxcd.io,resources=terraforms,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/tf_controller_backend.go
+++ b/controllers/tf_controller_backend.go
@@ -178,12 +178,17 @@ terraform {
 		tfrcFilepath = processCliConfigReply.FilePath
 	}
 
+	execType := r.ExecPath
+	if terraform.Spec.ExecType != "" && terraform.Spec.ExecType != r.ExecPath {
+		execType = terraform.Spec.ExecType
+	}
+
 	lookPathReply, err := runnerClient.LookPath(ctx,
 		&runner.LookPathRequest{
-			File: "terraform",
+			File: execType,
 		})
 	if err != nil {
-		err = fmt.Errorf("cannot find Terraform binary: %s in %s", err, os.Getenv("PATH"))
+		err = fmt.Errorf("cannot find binary: %s in %s: %w", execType, os.Getenv("PATH"), err)
 		return infrav1.TerraformNotReady(
 			terraform,
 			revision,

--- a/docs/References/terraform.md
+++ b/docs/References/terraform.md
@@ -1918,6 +1918,20 @@ Remediation
 fails. The default is to not perform any action.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>execType</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExecType specifies the type of executable used for the operations.
+It can be either &lsquo;terraform&rsquo; or &lsquo;tofu&rsquo;.
+If not specified, the default is set based on the global configuration.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2479,6 +2493,20 @@ Remediation
 <em>(Optional)</em>
 <p>Remediation specifies what the controller should do when reconciliation
 fails. The default is to not perform any action.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>execType</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExecType specifies the type of executable used for the operations.
+It can be either &lsquo;terraform&rsquo; or &lsquo;tofu&rsquo;.
+If not specified, the default is set based on the global configuration.</p>
 </td>
 </tr>
 </tbody>

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -3,6 +3,7 @@ FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TF_VERSION=1.5.7
+ARG TOFU_VERSION=1.6.2
 
 # Switch to root to have permissions for operations
 USER root
@@ -11,6 +12,11 @@ ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSIO
 RUN unzip -q /terraform_${TF_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
     rm /terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
     chmod +x /usr/local/bin/terraform
+
+ADD https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${TARGETARCH}.zip /tofu_${TOFU_VERSION}_linux_${TARGETARCH}.zip
+RUN unzip -q /tofu_${TOFU_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
+    rm /tofu_${TOFU_VERSION}_linux_${TARGETARCH}.zip && \
+    chmod +x /usr/local/bin/tofu
 
 # Switch back to the non-root user after operations
 USER 65532:65532

--- a/runner.Dockerfile.dev
+++ b/runner.Dockerfile.dev
@@ -28,6 +28,7 @@ FROM base
 
 ARG TARGETARCH
 ARG TF_VERSION=1.5.7
+ARG TOFU_VERSION=1.6.2
 
 # Switch to root to have permissions for operations
 USER root
@@ -36,6 +37,11 @@ ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSIO
 RUN unzip -q /terraform_${TF_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
     rm /terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
     chmod +x /usr/local/bin/terraform
+
+ADD https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${TARGETARCH}.zip /tofu_${TOFU_VERSION}_linux_${TARGETARCH}.zip
+RUN unzip -q /tofu_${TOFU_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
+    rm /tofu_${TOFU_VERSION}_linux_${TARGETARCH}.zip && \
+    chmod +x /usr/local/bin/tofu
 
 # Switch back to the non-root user after operations
 USER 65532:65532


### PR DESCRIPTION
Adds initial support for tofu by making the `execPath` setting configurable. It can be configured globally or per Terraform resource.

I also had to bump the controller-gen binary as I was not able to run `make manifests` with the old version, which resulted in some shifting of the descriptions in the CRD.