### PR TITLE
docs: remove weaveworks.github.io references from docs

### DIFF
--- a/docs/branch-planner/branch-planner-getting-started.md
+++ b/docs/branch-planner/branch-planner-getting-started.md
@@ -9,7 +9,7 @@ any additional permissions. For private repositories, you need the following per
   changes, list comments, and create or update comments.
   - `Metadata` with Read-only access. This is automatically marked as "mandatory"
   because of the permissions listed above.
-3. General knowledge about TF-Controller [(see docs)](https://weaveworks.github.io/tf-controller/).
+3. General knowledge about Tofu-Controller [(see docs)](https://flux-iac.github.io/tofu-controller/).
 
 ## Quick Start
 

--- a/docs/use-tf-controller/provision-resources-with-customized-runner-pods.md
+++ b/docs/use-tf-controller/provision-resources-with-customized-runner-pods.md
@@ -56,4 +56,4 @@ You can use [`runner.Dockerfile`](https://github.com/flux-iac/tofu-controller/bl
 ## Customize Runner Pod Specifications
 
 You can also customize various Runner Pod `spec` fields to control and configure how the Runner Pod runs. 
-For example, you can configure Runner Pod `spec` affinity and tolerations if you need to run in on a specific set of nodes. Please see [RunnerPodSpec](https://weaveworks.github.io/tf-controller/References/terraform/#infra.contrib.fluxcd.io/v1alpha2.RunnerPodSpec) for a list of the configurable Runner Pod `spec` fields.
+For example, you can configure Runner Pod `spec` affinity and tolerations if you need to run in on a specific set of nodes. Please see [RunnerPodSpec](https://flux-iac.github.io/tofu-controller/References/terraform/#infra.contrib.fluxcd.io/v1alpha2.RunnerPodSpec) for a list of the configurable Runner Pod `spec` fields.

--- a/docs/use-tf-controller/upgrade-tf-controller.md
+++ b/docs/use-tf-controller/upgrade-tf-controller.md
@@ -7,7 +7,7 @@ Please follow these steps to upgrade TF-Controller:
 3. To make sure you don't get new state changes, suspend Terraform resources (`tfctl suspend --all`) to minimize the impact on live systems.
 4. Back up Terraform tfstates to avoid losing data. If you're using the default backend with secrets in Kubernetes, use your backup toolset (i.e., Velero) to back up the state data.
 5. Upgrade Flux first, following [the Flux documentation](https://fluxcd.io/flux/installation/upgrade/).
-6. Disable [auto-approval](https://weaveworks.github.io/tf-controller/use_tf_controller/to_provision_resources_and_auto_approve/) by either removing the approvePlan value or setting it to "".
+6. Disable [auto-approval](https://flux-iac.github.io/tofu-controller/use-tf-controller/provision-resources-and-auto-approve/) by either removing the approvePlan value or setting it to "".
 7. To prevent unintentional resource deletions, set the `spec.destroyResourcesOnDeletion` flag to `false` for critical or production systems (the default value is `false`)
 8. If the Flux upgrade goes well, proceed to upgrade the TF-controller via its image tag. Adjust the values in the HelmRelease to match the new version to which you are upgrading.
 9. Check the pod logs for the TF-Controller deployment and any runner logs in order to identify potential issues. If you check the `warnings` in the logs, you can also identify any required API changes. For example:


### PR DESCRIPTION
While learning about features of ~~tf~~ tofu-controller I found some broken links to weaveworks.github.io which inspired me to fix them.
Hope this helps someone.