### PR TITLE
add recipe for installing and uninstalling rbac related resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,22 +182,34 @@ ifndef ignore-not-found
   ignore-not-found = false
 endif
 
+.PHONY: install-rbac
+install-rbac: manifests kustomize ## Install RBAC related manifests into the K8s cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build config/rbac | kubectl apply --server-side -f -
+
+.PHONY: uninstall-rbac
+install-rbac: manifests kustomize ## Uninstall RBAC related manifests from the K8s cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build config/rbac | kubectl delete --server-side --ignore-not-found=$(ignore-not-found) -f -
+
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl apply --server-side -f -
+	$(MAKE) install-rbac
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | kubectl delete --server-side --ignore-not-found=$(ignore-not-found) -f -
+	$(MAKE) uninstall-rbac
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image flux-iac/tofu-controller=${MANAGER_IMG}:${TAG}
 	$(KUSTOMIZE) build config/default | kubectl apply --server-side -f -
+	$(MAKE) install-rbac
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --server-side --ignore-not-found=$(ignore-not-found) -f -
+	$(MAKE) uninstall-rbac
 
 # Deploy controller dev image in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: dev-deploy


### PR DESCRIPTION
- While trying to run tf-controller locally on a kind cluster I noticed that the `tf-runner` service account along with other related resources for rbac weren't getting installed. I have raised a PR to fix that. If the installation of rbac resources was kept out of makefile intentionally then the pr can be closed without merging. 