### PR TITLE
Fix Incorrect Metric Reporting Post-Update in Terraform Controller

### DIFF
--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -136,7 +136,6 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		// Record Prometheus metrics.
-		r.Metrics.RecordReadiness(ctx, &terraform)
 		r.Metrics.RecordSuspend(ctx, &terraform, terraform.Spec.Suspend)
 		r.Metrics.RecordDuration(ctx, &terraform, reconcileStart)
 	}()


### PR DESCRIPTION
Fixes: #1068

This PR addresses a bug in the Tofu Controller where the gotk_reconcile_condition metrics for the Ready condition were not being accurately reported, causing the metrics to perpetually show as updating even after a successful update.

Issue:
Post-update, the metrics incorrectly reported Unknown=1 with True/False=0, due to the misuse of the original terraform variable in a deferred function. This variable held the Unknown condition and inadvertently overwrote the correctly updated metrics.

Root Cause:
The defer statement used the original terraform variable, which contained the Unknown condition. This action overwrote the metrics that were updated correctly elsewhere in the code at a different point ([see here](https://github.com/weaveworks/tf-controller/blob/1958307fc83cc56f486453885e9426cd88f93d80/controllers/tf_controller.go#L439)) using the reconciledTerraform variable.

Resolution:
The fix involves modifying the defer statement so it no longer updates the metric. This ensures that the metric updates performed through the reconciliation code in r.RecordReadiness are preserved and not overwritten by outdated data.

By merging this PR, the metrics accurately reflect the current state of Terraforms, thereby improving our system's reliability of status reporting.
