### PR TITLE
Speedup wait for pod ip

### DIFF
--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	kuberecorder "k8s.io/client-go/tools/record"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -82,6 +83,7 @@ type TerraformReconciler struct {
 	ClusterDomain             string
 	NoCrossNamespaceRefs      bool
 	UsePodSubdomainResolution bool
+	Clientset                 *kubernetes.Clientset
 }
 
 //+kubebuilder:rbac:groups=infra.contrib.fluxcd.io,resources=terraforms,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
The initial startup of a pod took atleast 15 seconds when waiting for an pod IP assignment. This change uses a watch on the pod instead of a polling mechanism which results in a much faster startup time. 

The only downside is that the clientset must be defined in the TerraformReconciler, however, the dependency is already existing. Improvement is noticeable in the e2e test where it perviously took 15 min where it now took 10 min.