### PR TITLE
Move hardcoded "flux-system" namespace from templates to default values

### DIFF
--- a/charts/tofu-controller/README.md
+++ b/charts/tofu-controller/README.md
@@ -79,12 +79,12 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 | rbac.create | bool | `true` | If `true`, create and use RBAC resources |
 | replicaCount | int | `1` | Number of tofu-controller pods to deploy |
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"200m","memory":"64Mi"}}` | Resource limits and requests |
-| runner | object | `{"creationTimeout":"5m0s","grpc":{"maxMessageSize":4},"image":{"repository":"ghcr.io/flux-iac/tf-runner","tag":"v0.16.0-rc.4"},"serviceAccount":{"allowedNamespaces":[],"annotations":{},"create":true,"name":""}}` | Runner-specific configurations |
+| runner | object | `{"creationTimeout":"5m0s","grpc":{"maxMessageSize":4},"image":{"repository":"ghcr.io/flux-iac/tf-runner","tag":"v0.16.0-rc.4"},"serviceAccount":{"allowedNamespaces":["flux-system"],"annotations":{},"create":true,"name":""}}` | Runner-specific configurations |
 | runner.creationTimeout | string | `"5m0s"` | Timeout for runner-creation (Controller) |
 | runner.grpc.maxMessageSize | int | `4` | Maximum GRPC message size (Controller) |
 | runner.image.repository | string | `"ghcr.io/flux-iac/tf-runner"` | Runner image repository |
 | runner.image.tag | string | `.Chart.AppVersion` | Runner image tag |
-| runner.serviceAccount.allowedNamespaces | list | `[]` | List of namespaces that the runner may run within |
+| runner.serviceAccount.allowedNamespaces | list | `["flux-system"]` | List of namespaces that the runner may run within (in addition to namespace of the controller itself) |
 | runner.serviceAccount.annotations | object | `{}` | Additional runner service Account annotations |
 | runner.serviceAccount.create | bool | `true` | If `true`, create a new runner service account |
 | runner.serviceAccount.name | string | `""` | Runner service account to be used |

--- a/charts/tofu-controller/templates/_helpers.tpl
+++ b/charts/tofu-controller/templates/_helpers.tpl
@@ -79,7 +79,6 @@ Create a unique list of runner allowed namespaces
 */}}
 {{- define "tofu-controller.runner.allowedNamespaces" -}}
 {{- $allowedNamespaces := append .Values.runner.serviceAccount.allowedNamespaces .Release.Namespace -}}
-{{- $allowedNamespaces := append $allowedNamespaces "flux-system" -}}
 {{- $allowedNamespaces = $allowedNamespaces | uniq -}}
 {{ toJson $allowedNamespaces }}
 {{- end }}

--- a/charts/tofu-controller/values.yaml
+++ b/charts/tofu-controller/values.yaml
@@ -132,8 +132,9 @@ runner:
     annotations: {}
     # -- Runner service account to be used
     name: ""
-    # -- List of namespaces that the runner may run within
-    allowedNamespaces: []
+    # -- List of namespaces that the runner may run within (in addition to namespace of the controller itself)
+    allowedNamespaces:
+    - flux-system
 # EKS-specific configurations
 # -- Create an AWS EKS Security Group Policy with the supplied Security Group IDs [See](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#deploy-securitygrouppolicy)
 eksSecurityGroupPolicy:


### PR DESCRIPTION
Helm will still use "flux-system" namespace by default, but now the user can override it.

fixes #1286