### PR TITLE
Print plan before apply

### DIFF
--- a/docs/use-tf-controller/with-tf-runner-logging.md
+++ b/docs/use-tf-controller/with-tf-runner-logging.md
@@ -19,3 +19,8 @@ the `DISABLE_TF_LOGS` variable must also be set to "1".
 
 For more information on configuring the Terraform Runner and its environment variables,
 please consult the documentation on [customizing runners](provision-resources-with-customized-runner-pods.md) within the Weave TF-controller.
+
+## Logging human-readable plan
+
+The plan can be logged in a human-readable format just before the applying it in the `tf-runner`.
+To enable this, set the environment variable `LOG_HUMAN_READABLE_PLAN` to "1" on the runner.

--- a/runner/server.go
+++ b/runner/server.go
@@ -382,6 +382,21 @@ func (r *TerraformRunnerServer) Apply(ctx context.Context, req *ApplyRequest) (*
 		applyOpt = append(applyOpt, tfexec.Parallelism(int(req.Parallelism)))
 	}
 
+	if os.Getenv("LOG_HUMAN_READABLE_PLAN") == "1" {
+		planName := TFPlanName
+		if req.DirOrPlan != "" {
+			planName = req.DirOrPlan
+		}
+
+		rawOutput, err := r.tfShowPlanFileRaw(ctx, planName)
+		if err != nil {
+			log.Error(err, "unable to get the plan output for human")
+			return nil, err
+		}
+
+		fmt.Println(rawOutput)
+	}
+
 	if err := r.tf.Apply(ctx, applyOpt...); err != nil {
 		st := status.New(codes.Internal, err.Error())
 		var stateErr *tfexec.ErrStateLocked

--- a/runner/server_test.go
+++ b/runner/server_test.go
@@ -1,0 +1,52 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+	. "github.com/onsi/gomega"
+)
+
+func Test_printHumanReadablePlanIfEnabled(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.Background()
+
+	defer func() {
+		g.Expect(os.Unsetenv("LOG_HUMAN_READABLE_PLAN")).Should(Succeed())
+	}()
+
+	var tfShowPlanFileRawCalled int
+	expectedPlan := TFPlanName
+	tfShowPlanFileRaw := func(ctx context.Context, planPath string, opts ...tfexec.ShowOption) (string, error) {
+		g.Expect(planPath).To(Equal(expectedPlan))
+		tfShowPlanFileRawCalled++
+		return "", nil
+	}
+
+	// When plan is enabled, then it should be called once
+	g.Expect(os.Setenv("LOG_HUMAN_READABLE_PLAN", "1")).Should(Succeed())
+	g.Expect(printHumanReadablePlanIfEnabled(ctx, "", tfShowPlanFileRaw)).Should(Succeed())
+	g.Expect(tfShowPlanFileRawCalled).To(Equal(1))
+
+	// When the planName is non-empty, then it should use the planName
+	expectedPlan = "foo"
+	g.Expect(printHumanReadablePlanIfEnabled(ctx, expectedPlan, tfShowPlanFileRaw)).Should(Succeed())
+	g.Expect(tfShowPlanFileRawCalled).To(Equal(2))
+
+	// When it is disabled, then it should not be called
+	expectedPlan = TFPlanName
+	g.Expect(os.Setenv("LOG_HUMAN_READABLE_PLAN", "0")).Should(Succeed())
+	g.Expect(printHumanReadablePlanIfEnabled(ctx, "", tfShowPlanFileRaw)).Should(Succeed())
+	g.Expect(tfShowPlanFileRawCalled).To(Equal(2))
+
+	// When tfShowPlanFileRaw fails, then it should return an error
+	g.Expect(os.Setenv("LOG_HUMAN_READABLE_PLAN", "1")).Should(Succeed())
+	tfShowPlanFileRaw = func(ctx context.Context, planPath string, opts ...tfexec.ShowOption) (string, error) {
+		return "", fmt.Errorf("error")
+	}
+
+	g.Expect(printHumanReadablePlanIfEnabled(ctx, "", tfShowPlanFileRaw)).ShouldNot(Succeed())
+}


### PR DESCRIPTION
Closes #1296 

Example output after testing:
```
kubectl logs -n flux-system sensitive-output-test-tf-runner
2024/06/04 04:56:51 Starting the runner... version  sha
{"level":"info","ts":"2024-06-04T04:56:52.618Z","logger":"runner.terraform","msg":"preparing for Upload and Extraction","instance-id":""}
{"level":"info","ts":"2024-06-04T04:56:52.618Z","logger":"runner.terraform","msg":"write backend config","instance-id":"","path":"/tmp/flux-system-sensitive-output-test/sensitive-output-test","config":"backend_override.tf"}
{"level":"info","ts":"2024-06-04T04:56:52.618Z","logger":"runner.terraform","msg":"write config to file","instance-id":"","filePath":"/tmp/flux-system-sensitive-output-test/sensitive-output-test/backend_override.tf"}
{"level":"info","ts":"2024-06-04T04:56:52.619Z","logger":"runner.terraform","msg":"looking for path","instance-id":"","file":"terraform"}
{"level":"info","ts":"2024-06-04T04:56:52.619Z","logger":"runner.terraform","msg":"creating new terraform","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0","workingDir":"/tmp/flux-system-sensitive-output-test/sensitive-output-test","execPath":"/usr/local/bin/terraform"}
{"level":"info","ts":"2024-06-04T04:56:52.621Z","logger":"runner.terraform","msg":"setting envvars","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:52.621Z","logger":"runner.terraform","msg":"getting envvars from os environments","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:52.621Z","logger":"runner.terraform","msg":"setting up the input variables","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:52.621Z","logger":"runner.terraform","msg":"mapping the Spec.Values","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:52.621Z","logger":"runner.terraform","msg":"mapping the Spec.Vars","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:52.621Z","logger":"runner.terraform","msg":"mapping the Spec.VarsFrom","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:52.622Z","logger":"runner.terraform","msg":"generating the template founds"}
{"level":"info","ts":"2024-06-04T04:56:52.622Z","logger":"runner.terraform","msg":"main.tf.tpl not found, skipping"}
{"level":"info","ts":"2024-06-04T04:56:52.623Z","logger":"runner.terraform","msg":"initializing","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:52.623Z","logger":"runner.terraform","msg":"mapping the Spec.BackendConfigsFrom","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:54.235Z","logger":"runner.terraform","msg":"workspace select"}
{"level":"info","ts":"2024-06-04T04:56:54.236Z","logger":"runner.terraform","msg":"creating a plan","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:54.399Z","logger":"runner.terraform","msg":"show the raw plan file","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:54.488Z","logger":"runner.terraform","msg":"creating a plan","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:54.704Z","logger":"runner.terraform","msg":"save the plan","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:54.723Z","logger":"runner.terraform","msg":"loading plan from secret","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:54.729Z","logger":"runner.terraform","msg":"running apply","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tls_private_key.example will be created
  + resource "tls_private_key" "example" {
      + algorithm                     = "ECDSA"
      + ecdsa_curve                   = "P224"
      + id                            = (known after apply)
      + private_key_openssh           = (sensitive value)
      + private_key_pem               = (sensitive value)
      + private_key_pem_pkcs8         = (sensitive value)
      + public_key_fingerprint_md5    = (known after apply)
      + public_key_fingerprint_sha256 = (known after apply)
      + public_key_openssh            = (known after apply)
      + public_key_pem                = (known after apply)
      + rsa_bits                      = 2048
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + hello_safe   = "Hello, World! I'm safe!"
  + hello_unsafe = (sensitive value)
  + private_key  = (sensitive value)

tls_private_key.example: Creating...
tls_private_key.example: Creation complete after 0s [id=4c819ec87937cfb17dc71c1dafde152c12c6bfd7]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

hello_safe = "Hello, World! I'm safe!"
hello_unsafe = <sensitive>
private_key = <sensitive>
{"level":"info","ts":"2024-06-04T04:56:54.919Z","logger":"runner.terraform","msg":"creating outputs","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0"}
{"level":"info","ts":"2024-06-04T04:56:54.953Z","logger":"runner.terraform","msg":"cleanup TmpDir","instance-id":"e2f92e7e-3c1a-4a9a-9496-c0e2691e79f0","tmpDir":"/tmp/flux-system-sensitive-output-test"}
```