### PR TITLE
Enable non-security dependency upgrades

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,19 +2,23 @@ version: 2
 
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/"
+      - "/api"
+      - "/tfctl"
     labels: ["area/ci", "dependencies"]
     schedule:
       interval: "weekly"
-    # Only do security updates not version updates.
-    open-pull-requests-limit: 0
     groups:
-      # Group all updates together, so that they are all applied in a single PR.
-      # Grouped updates are currently in beta and is subject to change.
-      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
-      ci:
-        patterns:
-          - "*"
+      go-patch:
+        update-types:
+        - "patch"
+      go-minor:
+        update-types:
+        - "minor"
+      go-major:
+        update-types:
+        - "major"
 
 
   # maintain dependencies for github actions


### PR DESCRIPTION
Tried to find out why non-security upgrades were turned off, but did not find any arguments in the [original PR](https://github.com/flux-iac/tofu-controller/pull/1145). 

I would assume it was due to noise? This might approve it a bit where we only get a maximum of three PRs with the new `directories` config in the dependabot.yml. 