### PR TITLE
Add LockTimeout to drift-detection mode

### DIFF
--- a/controllers/tf_controller_drift_detect.go
+++ b/controllers/tf_controller_drift_detect.go
@@ -79,6 +79,13 @@ func (r *TerraformReconciler) detectDrift(ctx context.Context, terraform infrav1
 		planRequest.Refresh = true
 	}
 
+	if terraform.Spec.TFState != nil {
+		if terraform.Spec.TFState.LockTimeout.Duration.String() != "" {
+			log.Info(fmt.Sprintf("LockTimeout is set: %s", terraform.Spec.TFState.LockTimeout))
+			planRequest.LockTimeout = terraform.Spec.TFState.LockTimeout.Duration.String()
+		}
+	}
+
 	eventSent := false
 	planReply, err := runnerClient.Plan(ctx, planRequest)
 	if err != nil {


### PR DESCRIPTION
Currently `LockTimeout` is implemented only for plan.
If Terraform is in drift-detection mode, there is no such option and the controller immediately returns the lock error.

The PR adds such functionality for the plan in drift-detection mode.