### PR TITLE
Allow drift detection for new objects in drift-detection mode

### DIFF
--- a/controllers/tf_controller_drift_detect.go
+++ b/controllers/tf_controller_drift_detect.go
@@ -26,13 +26,6 @@ func (r *TerraformReconciler) shouldDetectDrift(terraform infrav1.Terraform, rev
 		return false
 	}
 
-	// new object
-	if terraform.Status.LastAppliedRevision == "" &&
-		terraform.Status.LastPlannedRevision == "" &&
-		terraform.Status.LastAttemptedRevision == "" {
-		return false
-	}
-
 	if terraform.Spec.ApprovePlan == infrav1.ApprovePlanDisableValue {
 		return true
 	}

--- a/controllers/tf_controller_drift_detect.go
+++ b/controllers/tf_controller_drift_detect.go
@@ -30,6 +30,13 @@ func (r *TerraformReconciler) shouldDetectDrift(terraform infrav1.Terraform, rev
 		return true
 	}
 
+	// new object
+	if terraform.Status.LastAppliedRevision == "" &&
+		terraform.Status.LastPlannedRevision == "" &&
+		terraform.Status.LastAttemptedRevision == "" {
+		return false
+	}
+
 	// thing worked normally, no change pending
 	// then, we do drift detection
 	if terraform.Status.LastAttemptedRevision == terraform.Status.LastAppliedRevision &&


### PR DESCRIPTION
This PR fixes the issue for new objects created in drift-detection-only mode.
Current logic leaves Terraform CRD in Initializing status if it is created in drift detection mode.

A workaround requires manual intervention by setting `approvePlan` to something but not `disable`
 
 PR fixes 