### PR TITLE
Add remediateLastFailure

### DIFF
--- a/api/v1alpha2/terraform_types.go
+++ b/api/v1alpha2/terraform_types.go
@@ -286,6 +286,12 @@ type Remediation struct {
 	// retries.
 	// +optional
 	Retries int64 `json:"retries,omitempty"`
+
+	// RemediateLastFailure tells the controller to remediate the last failure, when
+	// no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+	// +optional
+	RemediateLastFailure *bool `json:"remediateLastFailure,omitempty"`
+
 }
 
 type CloudSpec struct {
@@ -952,6 +958,15 @@ func (in *Terraform) GetRetries() int64 {
 	}
 
 	return in.Spec.Remediation.Retries
+}
+
+// MustRemediateLastFailure returns whether to remediate the last failure when
+// no retries remain.
+func (in *Terraform) MustRemediateLastFailure() bool {
+	if in.Spec.Remediation.RemediateLastFailure == nil {
+		return false
+	}
+	return *in.Spec.Remediation.RemediateLastFailure
 }
 
 func (in *Terraform) GetReconciliationFailures() int64 {

--- a/charts/tofu-controller/crds/crds.yaml
+++ b/charts/tofu-controller/crds/crds.yaml
@@ -5082,6 +5082,12 @@ spec:
                       retries.
                     format: int64
                     type: integer
+                  remediateLastFailure:
+                    default: false
+                    description: |-
+                      remediateLastFailure instructs the controller to remediate the last failure
+                      when no retries remain. Defaults to false
+                    type: boolean
                 type: object
               retryInterval:
                 description: |-

--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -449,6 +449,16 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			terraform.GetGeneration(),
 		))
 
+		if terraform.MustRemediateLastFailure() {
+			log.Info("RemediateLastFailure is true, reseting retries, requeue after interval", "interval", terraform.Spec.Interval.Duration.String())
+			terraform = infrav1.TerraformResetRetry(terraform)
+			if err := r.patchStatus(ctx, req.NamespacedName, terraform.Status); err != nil {
+				log.Error(err, "unable to update status after maximum number of retries reached")
+				return ctrl.Result{Requeue: true}, err
+			}
+			return ctrl.Result{RequeueAfter: terraform.Spec.Interval.Duration}, nil
+		}
+
 		terraform = infrav1.TerraformReachedLimit(terraform)
 
 		traceLog.Info("Patch the status of the Terraform resource")


### PR DESCRIPTION
This PR adds `remediateLastFailure` to `Terraform` CRD, the same for example, Helm controller has.
Current logic leads to manual intervention when retries are exceeded. It prevents the scheduled execution for `Terraform` after `.spec.interval`. 
The new logic by default follows the old pattern but if `.spec.remediation.remediateLastFailure: true` controller will reset the retry count and schedule another `Terraform` execution after `.spec.interval` if retries exceeded.

Fixes https://github.com/flux-iac/tofu-controller/issues/1358