### PR TITLE
fix(helm-chart): ensure helm release namespace is applied

### DIFF
--- a/charts/tofu-controller/templates/controller-serviceaccount.yaml
+++ b/charts/tofu-controller/templates/controller-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "tofu-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tofu-controller.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/tofu-controller/templates/deployment.yaml
+++ b/charts/tofu-controller/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     {{- include "tofu-controller.labels" . | nindent 4 }}
   name: {{ include "tofu-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/tofu-controller/templates/metrics-svc.yaml
+++ b/charts/tofu-controller/templates/metrics-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "tofu-controller.fullname" . }}-metrics-service
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tofu-controller.labels" . | nindent 4 }}
 spec:

--- a/charts/tofu-controller/templates/packages.yaml
+++ b/charts/tofu-controller/templates/packages.yaml
@@ -3,6 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:
   name: aws-package
+  namespace: {{ .Release.Namespace }}
   annotations:
     metadata.weave.works/description: "This is the AWS package containing primitive modules for flux-iac tofu-controller."
     metadata.weave.works/docs-url: "https://github.com/flux-iac/aws-primitive-modules"

--- a/charts/tofu-controller/templates/planner-deployment.yaml
+++ b/charts/tofu-controller/templates/planner-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "planner.labels" . | nindent 4 }}
   name: {{ include "planner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   # Planner can't be scaled yet.
   replicas: 1


### PR DESCRIPTION
# Motivation

When testing various deployment configuration with `helm template`, some resources did not have the expected namespace.