### PR TITLE
feat(helm-chart): use automountServiceAccountToken on pod level

### DIFF
--- a/charts/tofu-controller/templates/controller-serviceaccount.yaml
+++ b/charts/tofu-controller/templates/controller-serviceaccount.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: false
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/charts/tofu-controller/templates/deployment.yaml
+++ b/charts/tofu-controller/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         {{- end }}
         {{- include "tofu-controller.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: true
       {{- if not .Values.serviceAccount.create }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/tofu-controller/templates/planner-deployment.yaml
+++ b/charts/tofu-controller/templates/planner-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{- end }}
         {{- include "planner.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: true
       {{- if not .Values.serviceAccount.create }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
# Motivation

By disabling it on ServiceAccount level and enabling it individually on pod level, security scanner expects it's more secure.
See for instance [C-0034](https://hub.armosec.io/docs/c-0034) from kubescape scanner or [this one](https://hub.datree.io/built-in-rules/prevent-service-account-token-auto-mount) from datree