### PR TITLE
chore: update alpine & tf versions

### DIFF
--- a/.github/workflows/release-runners.yaml
+++ b/.github/workflows/release-runners.yaml
@@ -75,7 +75,7 @@ jobs:
       packages: write # needed for ghcr access
     strategy:
       matrix:
-        tf_version: [1.0.11, 1.1.9, 1.2.9, 1.3.9, 1.4.6, 1.5.5]
+        tf_version: [1.0.11, 1.1.9, 1.2.9, 1.3.9, 1.4.6, 1.5.7, 1.6.6, 1.7.5, 1.8.5, 1.9.5]
     steps:
       - name: Check out
         uses: actions/checkout@b80ff79f1755d06ba70441c368a6fe801f5f3a62 # v4.0.0

--- a/runner-base.Dockerfile
+++ b/runner-base.Dockerfile
@@ -38,7 +38,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
         -o tf-runner \
         ./cmd/runner/main.go
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 LABEL org.opencontainers.image.source="https://github.com/flux-iac/tofu-controller"
 

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
-ARG TF_VERSION=1.5.7
+ARG TF_VERSION=1.9.5
 
 # Switch to root to have permissions for operations
 USER root

--- a/tools/check-runner-images.sh
+++ b/tools/check-runner-images.sh
@@ -5,7 +5,7 @@ IMAGE_NAME="ghcr.io/flux-iac/tf-runner"
 VERSION="${1}" # Assuming the desired version is passed as an argument to this script
 
 # Versions of Terraform to check
-TF_VERSIONS=(1.0.11 1.1.9 1.2.9 1.3.9 1.4.6 1.5.5 1.5.7)
+TF_VERSIONS=(1.0.11 1.1.9 1.2.9 1.3.9 1.4.6 1.5.7 1.6.6 1.7.5 1.8.5 1.9.5)
 
 # Loop over each Terraform version
 for TF_VERSION in "${TF_VERSIONS[@]}"; do


### PR DESCRIPTION
# What does it do ?

1. Update alpine to 3.20
2. Introduce build for latest 1.6.x, 1.7.x, 1.8.x and 1.9.x

# Motivation

I'm aware user can build their own runners, as documented [here](https://flux-iac.github.io/tofu-controller/use-tf-controller/build-and-use-a-custom-runner-image/).
I'm quite sure I'm not the only wanting to get a more recent version by default. Until there is a switch towards tofu-runner, I suggest with this PR to provide them.

# Notes

I kept the logic I have seen in https://github.com/flux-iac/tofu-controller/pull/1218 or https://github.com/flux-iac/tofu-controller/pull/528
The [upstream cli policy](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy) is not that wide. If maintainer prefers, the scope of this PR can be reduced to only provides the three latest TF version (1.9, 1.8 and 1.7).