### PR TITLE
feat/DependencyPaths: Allows specifying additional paths to signal resource creation when EnablePathScope is set

### DIFF
--- a/api/v1alpha2/terraform_types.go
+++ b/api/v1alpha2/terraform_types.go
@@ -273,6 +273,11 @@ type TerraformSpec struct {
 }
 
 type BranchPlanner struct {
+	// DependencyPaths specifies the paths to the directories that should be
+	// checked for changes. If any of the paths have changes, the Branch Planner
+	// will create extra resources for the Pull Request.
+	// +optional
+	DependencyPaths []string `json:"dependencyPaths"`
 	// EnablePathScope specifies if the Branch Planner should or shouldn't check
 	// if a Pull Request has changes under `.spec.path`. If enabled extra
 	// resources will be created only if there are any changes in terraform files.

--- a/charts/tofu-controller/crds/crds.yaml
+++ b/charts/tofu-controller/crds/crds.yaml
@@ -5360,6 +5360,14 @@ spec:
               branchPlanner:
                 description: BranchPlanner configuration.
                 properties:
+                  dependencyPaths:
+                    description: |-
+                      DependencyPaths specifies the paths that the Branch Planner should
+                      consider when checking if a Pull Request has changes under `.spec.path`.
+                      It should be used in conjunction with `enablePathScope`.
+                    items:
+                      type: string
+                    type: array
                   enablePathScope:
                     description: |-
                       EnablePathScope specifies if the Branch Planner should or shouldn't check

--- a/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
+++ b/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
@@ -5360,6 +5360,14 @@ spec:
               branchPlanner:
                 description: BranchPlanner configuration.
                 properties:
+                  dependencyPaths:
+                    description: |-
+                      DependencyPaths specifies the paths that the Branch Planner should
+                      consider when checking if a Pull Request has changes under `.spec.path`.
+                      It should be used in conjunction with `enablePathScope`.
+                    items:
+                      type: string
+                    type: array
                   enablePathScope:
                     description: |-
                       EnablePathScope specifies if the Branch Planner should or shouldn't check

--- a/docs/References/terraform.md
+++ b/docs/References/terraform.md
@@ -183,6 +183,21 @@ transient error will still result in a reconciliation failure.</p>
 <tbody>
 <tr>
 <td>
+<code>dependencyPaths</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DependecyPaths indicates directories that the branch planner should observe
+changes in when considering weather to generate a plan for a PR. The branch planner 
+will not attempt to plan terraform in these paths, but changes in them will signal
+to the planner that it should generate a plan for <code>.spec.path</code>.
+</td>
+</tr>
+<tr>
+<td>
 <code>enablePathScope</code><br>
 <em>
 bool
@@ -192,7 +207,8 @@ bool
 <em>(Optional)</em>
 <p>EnablePathScope specifies if the Branch Planner should or shouldn&rsquo;t check
 if a Pull Request has changes under <code>.spec.path</code>. If enabled extra
-resources will be created only if there are any changes in terraform files.</p>
+resources will be created only if there are any changes in terraform files. It should
+be used in conjunction with `enablePathScope`.</p>
 </td>
 </tr>
 </tbody>

--- a/internal/server/polling/trie.go
+++ b/internal/server/polling/trie.go
@@ -1,0 +1,40 @@
+package polling
+
+type TrieNode struct {
+	children map[rune]*TrieNode
+	isEnd    bool
+}
+
+// Trie represents the trie data structure
+type Trie struct {
+	root *TrieNode
+}
+
+// NewTrie creates a new trie
+func NewTrie() *Trie {
+	return &Trie{root: &TrieNode{children: make(map[rune]*TrieNode)}}
+}
+
+// Insert inserts a word into the trie
+func (t *Trie) Insert(word string) {
+	node := t.root
+	for _, ch := range word {
+		if _, exists := node.children[ch]; !exists {
+			node.children[ch] = &TrieNode{children: make(map[rune]*TrieNode)}
+		}
+		node = node.children[ch]
+	}
+	node.isEnd = true
+}
+
+// StartsWith checks if there is any word in the trie that starts with the given prefix
+func (t *Trie) StartsWith(prefix string) bool {
+	node := t.root
+	for _, ch := range prefix {
+		if _, exists := node.children[ch]; !exists {
+			return false
+		}
+		node = node.children[ch]
+	}
+	return true
+}


### PR DESCRIPTION
Allows specifying DependencyPaths property on the branch planner. When set in conjunction with `enablePathScope`, the branch planner will check the PR changes for additional matching paths specified in this array.

This addresses the use case of needing `enablePathScope` enabled for repos where there are many terraform states to remove noise, but at the same time requiring the planner to produce plans when changes to certain shared directories (like modules) are made.