### PR TITLE
switch hardcoded value for `terraform init -upgrade` to `false` (#1)

### DIFF
--- a/controllers/tf_controller_backend.go
+++ b/controllers/tf_controller_backend.go
@@ -344,7 +344,7 @@ terraform {
 
 	initRequest := &runner.InitRequest{
 		TfInstance: tfInstance,
-		Upgrade:    true,
+		Upgrade:    false, // ToDo: this should be configurable
 		ForceCopy:  true,
 		// Terraform:  terraformBytes,
 	}


### PR DESCRIPTION
During the turmoil around Hashicorp's aws provider `v5.71.0` we came up with the idea of pinning the provider via `.terraform.lock.hcl` which we injected through the `FileMappings` feature of tofu-controller.
Sadly this approach was sabotaged by this little boolean.

The boolean is equivalent to `terraform init -upgrade`

For us, as we do NOT usually ship `.terraform.lock.hcl`, this flag is not important and we would prefer it to be false.

Ideally this flag should be configurable but it requires a change in the `kind:Terraform` CRD.