### PR TITLE
Fix the HelmRelease scripts to install the latest helm chart

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -76,11 +76,11 @@ For more details about the Branch Planner, please visit the
 With Helm by:
 
 ```shell
-# Add tf-controller helm repository
-helm repo add tf-controller https://flux-iac.github.io/tofu-controller
+# Add tofu-controller helm repository
+helm repo add tofu-controller https://flux-iac.github.io/tofu-controller
 
-# Install tf-controller
-helm upgrade -i tf-controller tf-controller/tf-controller \
+# Install tofu-controller
+helm upgrade -i tofu-controller tofu-controller/tofu-controller \
     --namespace flux-system
 ```
 

--- a/docs/rc.yaml
+++ b/docs/rc.yaml
@@ -2,35 +2,38 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
-  name: tf-controller
+  name: tofu-controller
   namespace: flux-system
 spec:
   interval: 1h0s
-  type: oci
-  url: oci://ghcr.io/flux-iac/charts
+  url: https://flux-iac.github.io/tofu-controller
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
-  name: tf-controller
+  name: tofu-controller
   namespace: flux-system
 spec:
   chart:
     spec:
-      chart: tf-controller
+      chart: tofu-controller
       sourceRef:
         kind: HelmRepository
-        name: tf-controller
-      version: '0.16.0-rc.4'
+        name: tofu-controller
+      version: '0.16.0-rc.5'
   interval: 1h0s
-  releaseName: tf-controller
+  releaseName: tofu-controller
   targetNamespace: flux-system
   install:
     crds: Create
+    remediation:
+      retries: -1
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: -1
   values:
-    replicaCount: 1
+    replicaCount: 3
     concurrency: 24
     resources:
       limits:
@@ -42,7 +45,9 @@ spec:
     caCertValidityDuration: 24h
     certRotationCheckFrequency: 30m
     image:
-      tag: v0.16.0-rc.4
+      tag: v0.16.0-rc.5
     runner:
       image:
-        tag: v0.16.0-rc.4
+        tag: v0.16.0-rc.5
+      grpc:
+        maxMessageSize: 30

--- a/docs/release.yaml
+++ b/docs/release.yaml
@@ -2,28 +2,27 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
-  name: tf-controller
+  name: tofu-controller
   namespace: flux-system
 spec:
   interval: 1h0s
-  type: oci
-  url: oci://ghcr.io/flux-iac/charts
+  url: https://flux-iac.github.io/tofu-controller
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
-  name: tf-controller
+  name: tofu-controller
   namespace: flux-system
 spec:
   chart:
     spec:
-      chart: tf-controller
+      chart: tofu-controller
       sourceRef:
         kind: HelmRepository
-        name: tf-controller
-      version: '>=0.16.0-rc.5'
+        name: tofu-controller
+      version: '0.16.0-rc.5'
   interval: 1h0s
-  releaseName: tf-controller
+  releaseName: tofu-controller
   targetNamespace: flux-system
   install:
     crds: Create


### PR DESCRIPTION
## Summary

This PR fixes issue [#1508](https://github.com/flux-iac/tofu-controller/issues/1508)

Revised the YAML files used to install the latest release and RC release to install the renamed helm chart from what appears to be a new Helm chart repository.  Information was derived from the [manual installation instructions](https://flux-iac.github.io/tofu-controller/getting_started/#manual-installation).

## Testing

```
#
# Install
#
kubectl apply -f docs/release.yaml

#
# Illustrate that the expected version of helm chart was installed
#
flux get helmreleases
NAME            REVISION        SUSPENDED       READY   MESSAGE                                                                                                  
tofu-controller 0.16.0-rc.5     False           True    Helm install succeeded for release flux-system/tofu-controller.v1 with chart tofu-controller@0.16.0-rc.5
```

**Notes:**

* The file *docs/rc/yaml* is a copy of *docs/release.yaml*
