### PR TITLE
fix(ci): setup terraform

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -30,7 +30,7 @@ jobs:
           export TF_VERSION=1.3.9
           wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
           unzip -q terraform_${TF_VERSION}_linux_amd64.zip
-          mv terraform $(which terraform)
+          mv terraform /usr/local/bin
           terraform --version
       - name: Set up yq
         uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f # v1.0.2

--- a/.github/workflows/targeted-test.yaml
+++ b/.github/workflows/targeted-test.yaml
@@ -26,7 +26,7 @@ jobs:
           export TF_VERSION=1.3.9
           wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
           unzip -q terraform_${TF_VERSION}_linux_amd64.zip
-          mv terraform $(which terraform)
+          mv terraform /usr/local/bin
           terraform --version
       - name: Setup Kustomize
         if: "!github.event.pull_request.head.repo.fork"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,7 @@ jobs:
           export TF_VERSION=1.3.9
           wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
           unzip -q terraform_${TF_VERSION}_linux_amd64.zip
-          mv terraform $(which terraform)
+          mv terraform /usr/local/bin
           terraform --version
       - name: Setup Kustomize
         if: "!github.event.pull_request.head.repo.fork"
@@ -98,7 +98,7 @@ jobs:
           export TF_VERSION=1.3.9
           wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
           unzip -q terraform_${TF_VERSION}_linux_amd64.zip
-          mv terraform $(which terraform)
+          mv terraform /usr/local/bin
           terraform --version
       - name: Setup Kustomize
         if: "!github.event.pull_request.head.repo.fork"


### PR DESCRIPTION
The latest Ubuntu GitHub Action runners does not include the Terraform binary anymore: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

Therefore, overriding the Terraform binary no longer works, and we must instead copy the Terraform binary to PATH.