### PR TITLE
Bump the deprecated FluxCD versions

### DIFF
--- a/docs/release.yaml
+++ b/docs/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: tofu-controller
@@ -8,7 +8,7 @@ spec:
   interval: 1h0s
   url: https://flux-iac.github.io/tofu-controller
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tofu-controller


### PR DESCRIPTION
## Issues

This PR addresses the following issue

* https://github.com/flux-iac/tofu-controller/issues/1538

## Testing

Installed the operator using the revised script

```
% kubectl apply -f https://raw.githubusercontent.com/moconnor-cni/tofu-controller/refs/heads/main/docs/release.yaml
helmrepository.source.toolkit.fluxcd.io/tofu-controller created
helmrelease.helm.toolkit.fluxcd.io/tofu-controller created
```

The operator is installed as expected

```
% kubectl -n flux-system get helmrepository,helmrelease
NAME                                                      URL                                          AGE     READY   STATUS
helmrepository.source.toolkit.fluxcd.io/tofu-controller   https://flux-iac.github.io/tofu-controller   3m17s   True    stored artifact: revision 'sha256:d9d77a5cdbb5518fa9936a62fdda619f65ba3e08c48b11f4c6abdf50391f3d1e'

NAME                                                 AGE     READY   STATUS
helmrelease.helm.toolkit.fluxcd.io/tofu-controller   3m17s   True    Helm install succeeded for release flux-system/tofu-controller.v1 with chart tofu-controller@0.16.0-rc.5
```
