### PR TITLE
Rename Weave GitOps to tofu-controller

### DIFF
--- a/docs/tfctl.md
+++ b/docs/tfctl.md
@@ -7,7 +7,7 @@
 To install `tfctl` via Homebrew, run the following command:
 
 ```shell
-brew install weaveworks/tap/tfctl
+brew install flux-iac/tap/tfctl
 ```
 
 You can also download the `tfctl` binary via the GitHub releases page: [https://github.com/flux-iac/tofu-controller/releases](https://github.com/flux-iac/tofu-controller/releases).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Weave GitOps Terraform Controller
+site_name: "Tofu Controller: An IAC Controller for Flux"
 theme:
   name: material
   icon:
@@ -17,7 +17,7 @@ theme:
     - content.code.copy
 
 repo_url: https://github.com/flux-iac/tofu-controller
-repo_name: weaveworks/tf-controller
+repo_name: flux-iac/tofu-controller
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
Hi and thanks for the project!

I found the references to the old repo a bit disturbing while browsing the docs.

So here is a small PR to change references to the actual repo.

