### PR TITLE
chore: bump libcrypto to 3.3.4-r0

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CONTROLLER: ${{ github.event.repository.name }}
-  LIBCRYPTO_VERSION: "3.3.3-r0"
+  LIBCRYPTO_VERSION: "3.3.4-r0"
 
 jobs:
   test:

--- a/.github/workflows/release-runners.yaml
+++ b/.github/workflows/release-runners.yaml
@@ -18,7 +18,7 @@ permissions:
 env:
   VERSION: ${{ github.event.inputs.version }}
   BUILD_DATE: ${{ github.event.inputs.build_date }}
-  LIBCRYPTO_VERSION: "3.3.3-r0"
+  LIBCRYPTO_VERSION: "3.3.4-r0"
 
 jobs:
   release-base:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ permissions:
 
 env:
   CONTROLLER: ${{ github.event.repository.name }}
-  LIBCRYPTO_VERSION: "3.3.3-r0"
+  LIBCRYPTO_VERSION: "3.3.4-r0"
 
 jobs:
   build-push:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_VERSION ?= $(shell git describe --tags $$(git rev-list --tags --max-count=
 # - .github/workflows/release-runners.yaml
 # - .github/workflows/release.yaml
 # - Tiltfile
-LIBCRYPTO_VERSION ?= 3.3.3-r0
+LIBCRYPTO_VERSION ?= 3.3.4-r0
 
 # source controller version
 SOURCE_VER ?= v1.0.0-rc.1

--- a/Tiltfile
+++ b/Tiltfile
@@ -8,7 +8,7 @@ tfNamespace      = "terraform"
 buildSHA         = str(local('git rev-parse --short HEAD')).rstrip('\n')
 buildVersionRef  = str(local('git rev-list --tags --max-count=1')).rstrip('\n')
 buildVersion     = str(local("git describe --tags ${buildVersionRef}")).rstrip('\n')
-LIBCRYPTO_VERSION = "3.3.3-r0"
+LIBCRYPTO_VERSION = "3.3.4-r0"
 
 if os.path.exists('Tiltfile.local'):
    include('Tiltfile.local')


### PR DESCRIPTION
The current version breaks the build: https://github.com/flux-iac/tofu-controller/actions/runs/16344008698/job/46173053535