### PR TITLE
fix: use mutex-safe helpers in refreshCACertsIfNeeded to prevent map race

### DIFF
--- a/mtls/rotator.go
+++ b/mtls/rotator.go
@@ -416,12 +416,12 @@ func (cr *CertRotator) refreshCACertsIfNeeded() error {
 
 	if needRegeneration {
 		// generate new certs for all namespaces
-		for namespace := range cr.knownNamespaceTLSMap {
+		for _, namespace := range cr.GetKnownNamespaces() {
 			secret, err := cr.generateNamespaceTLS(namespace)
 			if err != nil {
 				crLog.Error(err, "could not generate TLS for namespace")
 			}
-			cr.knownNamespaceTLSMap[namespace] = &TriggerResult{Secret: secret, Err: err}
+			cr.SetKnownNamespaceTLS(namespace, &TriggerResult{Secret: secret, Err: err})
 		}
 	}
 


### PR DESCRIPTION
Direct iteration and writes to knownNamespaceTLSMap in refreshCACertsIfNeeded were unprotected by the mutex, causing a data race with the concurrent TriggerNamespaceTLSGeneration handler. Replace with GetKnownNamespaces() and SetKnownNamespaceTLS(), which both hold the mutex, eliminating the race.