### PR TITLE
fix: install azure-cli via pip in a virtualenv instead of copying binary

### DIFF
--- a/runner-azure.Dockerfile
+++ b/runner-azure.Dockerfile
@@ -1,13 +1,27 @@
 ARG BASE_IMAGE
 ARG TOFU_VERSION=1.11.6
 
-FROM mcr.microsoft.com/azure-cli:2.50.0 AS azcli
 FROM ghcr.io/opentofu/opentofu:${TOFU_VERSION}-minimal AS tofu
 
 FROM $BASE_IMAGE
 
-COPY --from=azcli /usr/local/bin/az /usr/local/bin/az 
+ARG AZURE_CLI_VERSION=2.86.0
+
+# Switch to root temporarily for package installation (base image runs as 65532).
+USER root
+
+# azure-cli is a pip package; installing just the binary is not sufficient.
+# We need Python and pip, then install the full azure-cli package.
+# Build dependencies (gcc, etc.) are needed to compile psutil, a C extension
+# required by azure-cli. They are removed after installation to keep image size down.
+RUN apk add --no-cache python3 py3-virtualenv gcc python3-dev musl-dev linux-headers && \
+    python3 -m venv /opt/az && \
+    /opt/az/bin/pip install --no-cache-dir setuptools azure-cli==${AZURE_CLI_VERSION} && \
+    ln -s /opt/az/bin/az /usr/local/bin/az && \
+    apk del gcc python3-dev musl-dev linux-headers
+
 COPY --from=tofu /usr/local/bin/tofu /usr/local/bin/tofu
 
 # Switch back to the non-root user after operations
 USER 65532:65532
+


### PR DESCRIPTION
Fix #1803

- Replace broken COPY --from=azcli with proper pip installation
- Use a Python venv (/opt/az) to isolate azure-cli from system packages
- Add gcc/python3-dev/musl-dev/linux-headers to compile psutil (C extension), remove them after install to keep image size down
- Add setuptools to restore distutils shim removed in Python 3.12
- Bump default AZURE_CLI_VERSION from 2.50.0 to 2.86.0 (latest), fixing mysql_flexibleservers import errors present in older versions
- Switch to USER root for install, restore USER 65532:65532 after