### PR TITLE
ci: fix image pushing when running on forks

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   CONTROLLER: ${{ github.event.repository.name }}
+  REGISTRY_OWNER: ${{ github.repository_owner }}
   LIBCRYPTO_VERSION: "3.5.6-r0"
 
 jobs:
@@ -82,7 +83,7 @@ jobs:
             LIBCRYPTO_VERSION=${{ env.LIBCRYPTO_VERSION }}
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           tags: |
-            ghcr.io/flux-iac/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -103,7 +104,7 @@ jobs:
             BUILD_SHA=${{ steps.prep.outputs.BUILD_SHA }}
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           tags: |
-            ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}-base
+            ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}-base
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -120,9 +121,9 @@ jobs:
           file: ./runner.Dockerfile
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           build-args: |
-            BASE_IMAGE=ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}-base
+            BASE_IMAGE=ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}-base
           tags: |
-            ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -141,7 +142,7 @@ jobs:
           build-args: |
             LIBCRYPTO_VERSION=${{ env.LIBCRYPTO_VERSION }}
           tags: |
-            ghcr.io/flux-iac/branch-planner:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/${{ env.REGISTRY_OWNER }}/branch-planner:${{ steps.prep.outputs.VERSION }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   CONTROLLER: ${{ github.event.repository.name }}
+  REGISTRY_OWNER: ${{ github.repository_owner }}
   LIBCRYPTO_VERSION: "3.5.6-r0"
 
 jobs:
@@ -75,8 +76,8 @@ jobs:
             LIBCRYPTO_VERSION=${{ env.LIBCRYPTO_VERSION }}
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           tags: |
-            ghcr.io/flux-iac/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
-            ghcr.io/flux-iac/${{ env.CONTROLLER }}:latest
+            ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.CONTROLLER }}:latest
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -95,7 +96,7 @@ jobs:
             LIBCRYPTO_VERSION=${{ env.LIBCRYPTO_VERSION }}
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           tags: |
-            ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}-base
+            ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}-base
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -113,10 +114,10 @@ jobs:
           file: ./runner.Dockerfile
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           build-args: |
-            BASE_IMAGE=ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}-base
+            BASE_IMAGE=ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}-base
           tags: |
-            ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}
-            ghcr.io/flux-iac/tf-runner:latest
+            ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:latest
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -134,10 +135,10 @@ jobs:
           file: ./runner-azure.Dockerfile
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7 - azure-cli does not install correctly on 32 bit arm
           build-args: |
-            BASE_IMAGE=ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}-base
+            BASE_IMAGE=ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}-base
           tags: |
-            ghcr.io/flux-iac/tf-runner-azure:${{ steps.prep.outputs.VERSION }}
-            ghcr.io/flux-iac/tf-runner-azure:latest
+            ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner-azure:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner-azure:latest
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -157,8 +158,8 @@ jobs:
             LIBCRYPTO_VERSION=${{ env.LIBCRYPTO_VERSION }}
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7 - azure-cli does not install correctly on 32 bit arm
           tags: |
-            ghcr.io/flux-iac/branch-planner:${{ steps.prep.outputs.VERSION }}
-            ghcr.io/flux-iac/branch-planner:latest
+            ghcr.io/${{ env.REGISTRY_OWNER }}/branch-planner:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/${{ env.REGISTRY_OWNER }}/branch-planner:latest
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -168,35 +169,35 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
       - name: Check images
         run: |
-          docker buildx imagetools inspect ghcr.io/flux-iac/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
-          docker pull ghcr.io/flux-iac/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
+          docker buildx imagetools inspect ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
+          docker pull ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
 
-          docker buildx imagetools inspect ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}
-          docker pull ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}
+          docker buildx imagetools inspect ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}
+          docker pull ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}
 
-          docker buildx imagetools inspect ghcr.io/flux-iac/tf-runner-azure:${{ steps.prep.outputs.VERSION }}
-          docker pull ghcr.io/flux-iac/tf-runner-azure:${{ steps.prep.outputs.VERSION }}
+          docker buildx imagetools inspect ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner-azure:${{ steps.prep.outputs.VERSION }}
+          docker pull ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner-azure:${{ steps.prep.outputs.VERSION }}
 
-          docker buildx imagetools inspect ghcr.io/flux-iac/branch-planner:${{ steps.prep.outputs.VERSION }}
-          docker pull ghcr.io/flux-iac/branch-planner:${{ steps.prep.outputs.VERSION }}
+          docker buildx imagetools inspect ghcr.io/${{ env.REGISTRY_OWNER }}/branch-planner:${{ steps.prep.outputs.VERSION }}
+          docker pull ghcr.io/${{ env.REGISTRY_OWNER }}/branch-planner:${{ steps.prep.outputs.VERSION }}
       - name: Sign images
         env:
           COSIGN_EXPERIMENTAL: 1
         run: |
-          cosign sign --yes ghcr.io/flux-iac/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
-          cosign sign --yes ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}-base
-          cosign sign --yes ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}
-          cosign sign --yes ghcr.io/flux-iac/tf-runner-azure:${{ steps.prep.outputs.VERSION }}
-          cosign sign --yes ghcr.io/flux-iac/branch-planner:${{ steps.prep.outputs.VERSION }}
+          cosign sign --yes ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
+          cosign sign --yes ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}-base
+          cosign sign --yes ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}
+          cosign sign --yes ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner-azure:${{ steps.prep.outputs.VERSION }}
+          cosign sign --yes ghcr.io/${{ env.REGISTRY_OWNER }}/branch-planner:${{ steps.prep.outputs.VERSION }}
       - name: Generate release manifests
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           mkdir -p config/release
           kustomize build ./config/crd > ./config/release/${{ env.CONTROLLER }}.crds.yaml
           kustomize build ./config/rbac > ./config/release/${{ env.CONTROLLER }}.rbac.yaml
-          kustomize build ./config/manager | yq e '.spec.template.spec.containers[0].env[1].value="ghcr.io/flux-iac/tf-runner:${{ steps.prep.outputs.VERSION }}"' - > ./config/release/${{ env.CONTROLLER }}.deployment.yaml
+          kustomize build ./config/manager | yq e '.spec.template.spec.containers[0].env[1].value="ghcr.io/${{ env.REGISTRY_OWNER }}/tf-runner:${{ steps.prep.outputs.VERSION }}"' - > ./config/release/${{ env.CONTROLLER }}.deployment.yaml
           kustomize build ./config/package > ./config/release/${{ env.CONTROLLER }}.packages.yaml
-          echo '[CHANGELOG](https://github.com/flux-iac/${{ env.CONTROLLER }}/blob/main/CHANGELOG.md)' > ./config/release/notes.md
+          echo '[CHANGELOG](${{ github.server_url }}/${{ github.repository }}/blob/main/CHANGELOG.md)' > ./config/release/notes.md
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:


### PR DESCRIPTION
Update the GitHub Actions workflows for building and releasing container images to make the image registry owner dynamic, rather than hardcoding it to `flux-iac`. This allows the workflows to run successfully across forks or other organizations by dynamically using the repository owner. The changes affect both the `build-and-publish.yaml` and `release.yaml` workflow files.

