### PR TITLE
fix: use stable CR UID label for Kubernetes backend state Secret lookup

### DIFF
--- a/api/v1alpha2/terraform_types.go
+++ b/api/v1alpha2/terraform_types.go
@@ -47,6 +47,11 @@ const (
 	BucketIndexKey          = ".metadata.bucket"
 	OCIRepositoryIndexKey   = ".metadata.ociRepository"
 	BreakTheGlassAnnotation = "break-the-glass.tf-controller/requestedAt"
+
+	// TFStateLabelKey is the label applied to Kubernetes-backend state Secrets.
+	// Value is the CR UID. Stable for the object lifetime regardless of
+	// metadata.labels changes, preventing stale-label state lookup failures.
+	TFStateLabelKey = "infra.contrib.fluxcd.io/terraform-state"
 )
 
 type ReadInputsFromSecretSpec struct {

--- a/controllers/tc000362_state_secret_label_test.go
+++ b/controllers/tc000362_state_secret_label_test.go
@@ -1,0 +1,188 @@
+package controllers
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	infrav1 "github.com/flux-iac/tofu-controller/api/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Test A — pure unit: getLabelsAsHCL emits only the internal label, not CR labels.
+func Test_000362_state_secret_label_hcl_uses_internal_label(t *testing.T) {
+	Spec("getLabelsAsHCL should emit only the internal label.")
+	g := NewWithT(t)
+	uid := "abc-123"
+	hcl := getLabelsAsHCL(map[string]string{
+		infrav1.TFStateLabelKey: uid,
+	}, 6)
+	g.Expect(hcl).To(ContainSubstring(infrav1.TFStateLabelKey))
+	g.Expect(hcl).To(ContainSubstring(uid))
+	g.Expect(hcl).NotTo(ContainSubstring("app"))
+	g.Expect(hcl).NotTo(ContainSubstring("env"))
+}
+
+// Test C — integration: migration patches a legacy Secret that has no internal label.
+func Test_000362_state_secret_migration_patches_legacy_secret(t *testing.T) {
+	Spec("migrateStateSecretLabel should patch a pre-fix Secret with the CR UID label.")
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	const namespace = "flux-system"
+	const crName = "tc000362-migrate-legacy"
+	const fakeUID = types.UID("uid-migrate-legacy")
+
+	// Use an in-memory CR so the reconciler never picks it up (no finalizer issues).
+	cr := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: namespace,
+			UID:       fakeUID,
+			Labels:    map[string]string{"app": "foo"},
+		},
+	}
+
+	By("creating a legacy state Secret with CR labels but no internal label.")
+	secretName := fmt.Sprintf("tfstate-default-%s", crName)
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "foo"},
+		},
+	}
+	g.Expect(k8sClient.Create(ctx, &secret)).To(Succeed())
+	defer waitResourceToBeDelete(g, &secret)
+
+	By("calling migrateStateSecretLabel.")
+	r := &TerraformReconciler{Client: k8sClient, FieldManager: "tf-controller"}
+	g.Expect(r.migrateStateSecretLabel(ctx, cr)).To(Succeed())
+
+	By("verifying the Secret gained the internal UID label.")
+	var patched corev1.Secret
+	g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, &patched)).To(Succeed())
+	g.Expect(patched.Labels[infrav1.TFStateLabelKey]).To(Equal(string(fakeUID)))
+}
+
+// Test D — integration: label change on CR does not affect an already-migrated Secret.
+func Test_000362_state_secret_label_change_does_not_affect_migrated_secret(t *testing.T) {
+	Spec("migrateStateSecretLabel should be a no-op when the Secret already has the UID label.")
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	const namespace = "flux-system"
+	const crName = "tc000362-label-change"
+	const fakeUID = types.UID("uid-label-change")
+
+	cr := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: namespace,
+			UID:       fakeUID,
+			Labels:    map[string]string{"app": "old"},
+		},
+	}
+
+	By("creating a state Secret that is already migrated (has the UID label).")
+	secretName := fmt.Sprintf("tfstate-default-%s", crName)
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":                   "old",
+				infrav1.TFStateLabelKey: string(fakeUID),
+			},
+		},
+	}
+	g.Expect(k8sClient.Create(ctx, &secret)).To(Succeed())
+	defer waitResourceToBeDelete(g, &secret)
+
+	By("simulating a CR label mutation to {app: new}.")
+	cr.Labels = map[string]string{"app": "new"}
+
+	By("calling migrateStateSecretLabel with the updated CR.")
+	r := &TerraformReconciler{Client: k8sClient, FieldManager: "tf-controller"}
+	g.Expect(r.migrateStateSecretLabel(ctx, cr)).To(Succeed())
+
+	By("verifying the Secret UID label is unchanged.")
+	var got corev1.Secret
+	g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, &got)).To(Succeed())
+	g.Expect(got.Labels[infrav1.TFStateLabelKey]).To(Equal(string(fakeUID)))
+}
+
+// Test E — integration: no state Secret → migration is a no-op (NotFound path).
+func Test_000362_state_secret_migration_no_secret_is_noop(t *testing.T) {
+	Spec("migrateStateSecretLabel should return nil when no state Secret exists.")
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	const namespace = "flux-system"
+	const crName = "tc000362-no-secret"
+
+	cr := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: namespace,
+			UID:       types.UID("uid-no-secret"),
+		},
+	}
+
+	By("calling migrateStateSecretLabel with no state Secret present.")
+	r := &TerraformReconciler{Client: k8sClient, FieldManager: "tf-controller"}
+	g.Expect(r.migrateStateSecretLabel(ctx, cr)).To(Succeed())
+}
+
+// Test F — integration: calling migration twice is idempotent.
+func Test_000362_state_secret_migration_is_idempotent(t *testing.T) {
+	Spec("migrateStateSecretLabel should be idempotent — a second call is a no-op.")
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	const namespace = "flux-system"
+	const crName = "tc000362-idempotent"
+	const fakeUID = types.UID("uid-idempotent")
+
+	cr := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: namespace,
+			UID:       fakeUID,
+		},
+	}
+
+	By("creating a legacy Secret without the internal label.")
+	secretName := fmt.Sprintf("tfstate-default-%s", crName)
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels:    map[string]string{"legacy": "true"},
+		},
+	}
+	g.Expect(k8sClient.Create(ctx, &secret)).To(Succeed())
+	defer waitResourceToBeDelete(g, &secret)
+
+	r := &TerraformReconciler{Client: k8sClient, FieldManager: "tf-controller"}
+
+	By("calling migrateStateSecretLabel the first time.")
+	g.Expect(r.migrateStateSecretLabel(ctx, cr)).To(Succeed())
+
+	var afterFirst corev1.Secret
+	g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, &afterFirst)).To(Succeed())
+	g.Expect(afterFirst.Labels[infrav1.TFStateLabelKey]).To(Equal(string(fakeUID)))
+
+	By("calling migrateStateSecretLabel a second time.")
+	g.Expect(r.migrateStateSecretLabel(ctx, cr)).To(Succeed())
+
+	By("verifying the Secret labels are unchanged after the second call.")
+	var afterSecond corev1.Secret
+	g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, &afterSecond)).To(Succeed())
+	g.Expect(afterSecond.Labels[infrav1.TFStateLabelKey]).To(Equal(string(fakeUID)))
+	g.Expect(afterSecond.ResourceVersion).To(Equal(afterFirst.ResourceVersion))
+}

--- a/controllers/tf_controller_backend.go
+++ b/controllers/tf_controller_backend.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *TerraformReconciler) backendCompletelyDisable(terraform *infrav1.Terraform) bool {
@@ -96,7 +97,9 @@ terraform {
 			terraform.Spec.BackendConfig.InClusterConfig,
 			terraform.Spec.BackendConfig.ConfigPath,
 			terraform.Namespace,
-			getLabelsAsHCL(terraform.Labels, 6))
+			getLabelsAsHCL(map[string]string{
+				infrav1.TFStateLabelKey: string(terraform.UID),
+			}, 6))
 	} else if DisableTFK8SBackend && terraform.Spec.BackendConfig == nil {
 		backendConfig = `
 terraform {
@@ -118,7 +121,9 @@ terraform {
 `,
 			terraform.Name,
 			terraform.Namespace,
-			getLabelsAsHCL(terraform.Labels, 6))
+			getLabelsAsHCL(map[string]string{
+				infrav1.TFStateLabelKey: string(terraform.UID),
+			}, 6))
 	}
 
 	if r.backendCompletelyDisable(terraform) {
@@ -137,6 +142,14 @@ terraform {
 			log.Info(fmt.Sprintf("write cloud config: %s", writeBackendConfigReply.Message))
 		}
 	} else {
+		if err := r.migrateStateSecretLabel(ctx, terraform); err != nil {
+			return infrav1.TerraformNotReady(
+				terraform,
+				revision,
+				infrav1.TFExecInitFailedReason,
+				fmt.Sprintf("migrate state secret label: %s", err),
+			), tfInstance, tmpDir, err
+		}
 		writeBackendConfigReply, err := runnerClient.WriteBackendConfig(ctx,
 			&runner.WriteBackendConfigRequest{
 				DirPath:       workingDir,
@@ -441,4 +454,44 @@ func getLabelsAsHCL(labels map[string]string, indent int) string {
 	}
 
 	return strings.TrimSpace(result)
+}
+
+func (r *TerraformReconciler) migrateStateSecretLabel(
+	ctx context.Context,
+	terraform *infrav1.Terraform,
+) error {
+	suffix := terraform.Name
+	if terraform.Spec.BackendConfig != nil {
+		suffix = terraform.Spec.BackendConfig.SecretSuffix
+	}
+	secretName := fmt.Sprintf("tfstate-%s-%s", terraform.WorkspaceName(), suffix)
+
+	var secret corev1.Secret
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: terraform.Namespace,
+		Name:      secretName,
+	}, &secret); err != nil {
+		return client.IgnoreNotFound(fmt.Errorf("failed to get state secret %s for migration: %w", secretName, err))
+	}
+
+	uid := string(terraform.UID)
+	if secret.Labels[infrav1.TFStateLabelKey] == uid {
+		return nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	patch := client.MergeFrom(secret.DeepCopy())
+	if secret.Labels == nil {
+		secret.Labels = make(map[string]string)
+	}
+	secret.Labels[infrav1.TFStateLabelKey] = uid
+	if err := r.Patch(ctx, &secret, patch,
+		client.FieldOwner(r.FieldManager)); err != nil {
+		return fmt.Errorf(
+			"failed to patch state secret %s with internal label: %w",
+			secretName, err)
+	}
+	log.Info("migrated state secret to internal label",
+		"secret", secretName, "uid", uid)
+	return nil
 }


### PR DESCRIPTION
## Problem

The Kubernetes backend HCL was built using `getLabelsAsHCL(terraform.Labels, 6)`, which propagates whatever labels are on the `Terraform` CR into the `labels` selector of the backend config. If `metadata.labels` on the CR are mutated after the first `tofu init`, the backend can no longer find the existing state Secret and bootstraps an empty workspace instead — silently destroying pending state.

Related: #1774

## Solution

Replace both `getLabelsAsHCL(terraform.Labels, 6)` calls with a single, stable internal label:

```
infra.contrib.fluxcd.io/terraform-state = <CR UID>
```

The CR UID is immutable for the object lifetime, so label mutations on the CR can never shift the selector.

### Migration

A new `migrateStateSecretLabel` method is called at the top of the non-disabled backend branch in `setupTerraform`, before `WriteBackendConfig`. It:

1. Derives the state Secret name deterministically (`tfstate-<workspace>-<suffix>`) — the same logic the Terraform kubernetes backend uses.
2. GETs the Secret by name (not by label), so it is found even if CR labels already changed before this fix was deployed.
3. If the Secret lacks the internal label, patches it with `client.MergeFrom` + `r.Patch`.
4. Is a no-op if the label is already correct (idempotent) or if no Secret exists yet (new CR).

## Changes

| File | Change |
|------|--------|
| `api/v1alpha2/terraform_types.go` | Add `TFStateLabelKey = "infra.contrib.fluxcd.io/terraform-state"` constant |
| `controllers/tf_controller_backend.go` | Replace `terraform.Labels` in both HCL paths; add `migrateStateSecretLabel`; wire migration call in `setupTerraform` |
| `controllers/tc000362_state_secret_label_test.go` | 5 new tests covering: HCL label isolation, legacy Secret patching, label-change safety, NotFound no-op, idempotency |

## Test plan

- [x] `make TARGET=000362 target-test` — all 5 tests pass
- [x] `make normal-controller-test` — no regressions
- [x] `go build ./controllers/... && go vet ./controllers/...` — clean
- [ ] e2e: `./local-e2e.sh` — state Secret created with `infra.contrib.fluxcd.io/terraform-state` label after `tofu init`