### PR TITLE
fix: make local dev tooling work on Apple Silicon and containerd v2

### DIFF
--- a/local-e2e.sh
+++ b/local-e2e.sh
@@ -3,7 +3,18 @@
 # Exit the script if any command fails
 set -e
 
+# On Apple Silicon Macs the default amd64 kindest/node image causes the kubelet to fail.
+# Force native arm64 images so kind bootstraps correctly on arm64 hosts.
+case "$(uname -m)" in
+  arm64|aarch64)
+    export DOCKER_DEFAULT_PLATFORM=linux/arm64
+    ;;
+esac
+
 VERSION=e2e-$(git rev-parse --short HEAD)-$(if [[ $(git diff --stat) != '' ]]; then echo 'dirty'; else echo 'clean'; fi)
+
+# Delete any leftover cluster from a previous run so this script is idempotent
+kind delete cluster 2>/dev/null || true
 
 kind create cluster
 
@@ -34,7 +45,7 @@ kubectl -n tofu-system rollout status deploy/source-controller --timeout=1m
 kubectl -n tofu-system rollout status deploy/tofu-controller --timeout=1m
 
 echo "==================== Show Terraform version"
-docker run --rm --entrypoint=/usr/local/bin/terraform test/tf-runner:$VERSION version
+docker run --rm --entrypoint=/usr/local/bin/tofu test/tf-runner:$VERSION version
 
 echo "==================== Add git repository source"
 kubectl -n tofu-system apply -f ./config/testdata/source

--- a/tools/reboot.sh
+++ b/tools/reboot.sh
@@ -19,6 +19,15 @@
 
 set -o errexit
 
+# On Apple Silicon Macs where Docker Desktop defaults to amd64/Rosetta 2 emulation,
+# the kindest/node amd64 image causes the kubelet to fail at health-check time.
+# Force native arm64 images so kind bootstraps correctly on arm64 hosts.
+case "$(uname -m)" in
+  arm64|aarch64)
+    export DOCKER_DEFAULT_PLATFORM=linux/arm64
+    ;;
+esac
+
 # desired cluster name; default is "tfdev"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-tfdev}"
 KIND_CLUSTER_OPTS="--name ${KIND_CLUSTER_NAME}"
@@ -45,7 +54,7 @@ running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || t
 if [ "${running}" != 'true' ]; then
   docker run \
     -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
-    registry:2
+    registry:3
 fi
 
 reg_host="${reg_name}"
@@ -57,15 +66,27 @@ echo "Registry Host: ${reg_host}"
 # delete previous cluster, if any
 kind delete cluster --name=${KIND_CLUSTER_NAME} || true
 
-# create a cluster with the local registry enabled in containerd
+# create a cluster with containerd configured to use per-registry hosts.toml files
+# (containerd v2 removed registry.mirrors in favour of config_path + hosts.toml)
 cat <<EOF | kind create cluster ${KIND_CLUSTER_OPTS} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
-    endpoint = ["http://${reg_host}:5000"]
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
 EOF
+
+# Wire the local registry mirror into each node via a hosts.toml file.
+# extraMounts cannot be used here because the container path contains a colon
+# (localhost:PORT) which Docker's --volume flag treats as a delimiter.
+for node in $(kind get nodes --name ${KIND_CLUSTER_NAME}); do
+  docker exec "${node}" mkdir -p "/etc/containerd/certs.d/localhost:${reg_port}"
+  docker exec -i "${node}" sh -c "cat > /etc/containerd/certs.d/localhost:${reg_port}/hosts.toml" <<HOSTS
+[host."http://${reg_host}:5000"]
+  capabilities = ["pull", "resolve", "push"]
+HOSTS
+done
 
 cat <<EOF | kubectl apply -f -
 apiVersion: v1


### PR DESCRIPTION
## Summary

- **`local-e2e.sh`**: set `DOCKER_DEFAULT_PLATFORM=linux/arm64` on arm64/aarch64 hosts so `kind` bootstraps with native images (fixes kubelet health-check failures on Apple Silicon); add idempotent `kind delete cluster` before `kind create cluster`; fix tf-runner version probe entrypoint (`/usr/local/bin/tofu`, not `terraform`)
- **`tools/reboot.sh`**: same arm64 platform guard; migrate containerd registry config from the removed `registry.mirrors` TOML key to the `config_path` + per-node `hosts.toml` approach required by containerd v2; bump registry image from `registry:2` to `registry:3`

## Motivation

Both scripts failed on Apple Silicon Macs and on any host running containerd v2 (the default in current Docker Desktop and kind ≥ 0.23). These are purely local-tooling fixes with no impact on the operator itself.

## Test plan

- [x] Run `./tools/reboot.sh && tilt up` on an Apple Silicon Mac — cluster bootstraps without kubelet failures and the local registry is reachable
- [x] Run `./local-e2e.sh` on an Apple Silicon Mac — script is idempotent across repeated runs and the tf-runner version probe prints the correct `tofu` version (`OpenTofu v1.12.1`)