### PR TITLE
fix: install libc6-compat in runner image to fix boundary provider plan

### DIFF
--- a/runner-base.Dockerfile
+++ b/runner-base.Dockerfile
@@ -49,6 +49,7 @@ RUN apk update && \
     busybox \
     ca-certificates \
     git \
+    libc6-compat \
     gnupg \
     libcrypto3=${LIBCRYPTO_VERSION} \
     libssl3=${LIBCRYPTO_VERSION} \


### PR DESCRIPTION
fix #1824 

The hashicorp/boundary provider fails to plan when using the provider with : recovery_kms_hcl

This seems a https://github.com/hashicorp/terraform-provider-boundary/issues/384when using the provider on alpine, a solution is to install the libc6-compat via apk into the runner.base