### PR TITLE
chore!: remove unused option "--cert-validity-duration"

### DIFF
--- a/charts/tofu-controller/README.md
+++ b/charts/tofu-controller/README.md
@@ -42,7 +42,6 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 | branchPlanner | object | `{"configMap":"branch-planner","deploymentLabels":{},"enabled":false,"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/flux-iac/branch-planner","tag":""},"podSecurityContext":{"fsGroup":1337},"pollingInterval":"30s","resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"200m","memory":"64Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}},"sourceInterval":"30s"}` | Branch Planner-specific configurations |
 | caCertValidityDuration | string | `"168h0m"` | Argument for `--ca-cert-validity-duration` (Controller) |
 | certRotationCheckFrequency | string | `"30m0s"` | Argument for `--cert-rotation-check-frequency` (Controller) |
-| certValidityDuration | string | `"6h0m"` | Argument for `--cert-validity-duration` (Controller) |
 | clusterDomain | string | `"cluster.local"` | Argument for `--cluster-domain` (Controller).  ClusterDomain indicates the cluster domain, defaults to cluster.local. |
 | concurrency | int | `24` | Concurrency of the controller (Controller) |
 | deploymentLabels | object | `{}` | Additional deployment labels for the controller |

--- a/charts/tofu-controller/templates/deployment.yaml
+++ b/charts/tofu-controller/templates/deployment.yaml
@@ -42,7 +42,6 @@ spec:
         - --concurrent={{ .Values.concurrency }}
         - --ca-cert-validity-duration={{ .Values.caCertValidityDuration }}
         - --cert-rotation-check-frequency={{ .Values.certRotationCheckFrequency }}
-        - --cert-validity-duration={{ .Values.certValidityDuration }}
         - --runner-creation-timeout={{ .Values.runner.creationTimeout }}
         - --runner-grpc-max-message-size={{ .Values.runner.grpc.maxMessageSize }}
         - --events-addr={{ .Values.eventsAddress }}

--- a/charts/tofu-controller/values.yaml
+++ b/charts/tofu-controller/values.yaml
@@ -89,8 +89,6 @@ logLevel: info
 concurrency: 24
 # -- Argument for `--cert-rotation-check-frequency` (Controller)
 certRotationCheckFrequency: 30m0s
-# -- Argument for `--cert-validity-duration` (Controller)
-certValidityDuration: 6h0m
 # -- Argument for `--ca-cert-validity-duration` (Controller)
 caCertValidityDuration: 168h0m
 # -- Argument for `--events-addr` (Controller). The event address, default to the address of the Notification Controller

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -88,7 +88,6 @@ func main() {
 		watchAllNamespaces        bool
 		httpRetry                 int
 		caValidityDuration        time.Duration
-		certValidityDuration      time.Duration
 		rotationCheckFrequency    time.Duration
 		runnerGRPCPort            int
 		runnerCreationTimeout     time.Duration
@@ -114,9 +113,7 @@ func main() {
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
 	flag.DurationVar(&caValidityDuration, "ca-cert-validity-duration", 24*7*time.Hour,
-		"The duration that the ca certificate certificates should be valid for. Default is 1 week.")
-	flag.DurationVar(&certValidityDuration, "cert-validity-duration", 6*time.Hour,
-		"(Deprecated) The duration that the mTLS certificate that the runner pod should be valid for.")
+		"The duration that the CA/mTLS certificates should be valid for. Default is 1 week.")
 	flag.DurationVar(&rotationCheckFrequency, "cert-rotation-check-frequency", 30*time.Minute,
 		"The interval that the mTLS certificate rotator should check the certificate validity.")
 	flag.IntVar(&runnerGRPCPort, "runner-grpc-port", 30000, "The port which will be exposed on the runner pod for gRPC connections.")

--- a/mtls/rotator.go
+++ b/mtls/rotator.go
@@ -78,11 +78,10 @@ type CertRotator struct {
 	extKeyUsages *[]x509.ExtKeyUsage
 	Ready        chan struct{}
 
-	CAName             string
-	CAOrganization     string
-	DNSName            string
-	CAValidityDuration time.Duration
-	// CertValidityDuration   time.Duration
+	CAName                 string
+	CAOrganization         string
+	DNSName                string
+	CAValidityDuration     time.Duration
 	RotationCheckFrequency time.Duration
 	LookaheadInterval      time.Duration
 


### PR DESCRIPTION
This option has been unused for the long time. Other option "--ca-cert-validity-duration" is actually responsible for all certs duration, not just CA.

It was extra confusing that it's marked as "Deprecated", which normally means "it still works but you should not use it", while in reality it was completely ignored. The fact that helm chart still set it only added to the confusion.