### PR TITLE
feat: allow reading sources from additional namespaces when watching a single namespace

### DIFF
--- a/charts/tofu-controller/README.md
+++ b/charts/tofu-controller/README.md
@@ -33,6 +33,7 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalSourceNamespaces | list | `[]` | List of additional namespaces from which source objects (GitRepository, Bucket, OCIRepository) may be read when watchAllNamespaces is false. Ignored when watchAllNamespaces is true. |
 | affinity | object | `{}` | Affinity properties for the tofu-controller deployment |
 | allowBreakTheGlass | bool | `false` | Argument for `--allow-break-the-glass` (Controller).  AllowBreakTheGlass allows the controller to break the glass and modify Terraform states when the sync loop is broken. |
 | allowCrossNamespaceRefs | bool | `false` | If `true`, enable cross-namespace references for controller and branch-planner |

--- a/charts/tofu-controller/templates/deployment.yaml
+++ b/charts/tofu-controller/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
       - args:
         - --allow-cross-namespace-refs={{ .Values.allowCrossNamespaceRefs }}
         - --watch-all-namespaces={{ .Values.watchAllNamespaces }}
+        {{- with .Values.additionalSourceNamespaces }}
+        - --additional-source-namespaces={{ join "," . }}
+        {{- end }}
         - --log-level={{ .Values.logLevel }}
         - --log-encoding={{ .Values.logEncoding }}
         - --enable-leader-election

--- a/charts/tofu-controller/values.yaml
+++ b/charts/tofu-controller/values.yaml
@@ -2,6 +2,9 @@
 allowCrossNamespaceRefs: false
 # -- If `true`, controller will watch all namespaces for Terraform resources
 watchAllNamespaces: true
+# -- List of additional namespaces from which source objects (GitRepository, Bucket, OCIRepository)
+# may be read when watchAllNamespaces is false. Ignored when watchAllNamespaces is true.
+additionalSourceNamespaces: []
 # ServiceAccount
 serviceAccount:
   # -- If `true`, create a new service account

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"time"
 
 	"github.com/flux-iac/tofu-controller/mtls"
@@ -41,6 +42,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -75,33 +77,84 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
+// buildCacheOptions returns the cache configuration for the manager. When
+// watchNamespace is empty (the controller is watching all namespaces), it
+// returns a zero-value Options — a full no-op, since the cache already
+// covers everything. When watchNamespace is set, Terraform CRs stay scoped
+// to that namespace (DefaultNamespaces), but the three source kinds
+// (GitRepository, Bucket, OCIRepository) additionally get their own
+// namespace scope covering watchNamespace plus any additionalSourceNamespaces
+// — letting a namespace-scoped instance resolve sources centralized in a
+// different namespace without widening what it actually reconciles.
+func buildCacheOptions(watchNamespace string, additionalSourceNamespaces []string) ctrlcache.Options {
+	if watchNamespace == "" {
+		return ctrlcache.Options{}
+	}
+
+	opts := ctrlcache.Options{
+		DefaultNamespaces: map[string]ctrlcache.Config{
+			watchNamespace: ctrlcache.Config{},
+		},
+	}
+
+	hasAdditional := false
+	for _, ns := range additionalSourceNamespaces {
+		if strings.TrimSpace(ns) != "" {
+			hasAdditional = true
+			break
+		}
+	}
+	if !hasAdditional {
+		return opts
+	}
+
+	newSourceNamespaces := func() map[string]ctrlcache.Config {
+		m := map[string]ctrlcache.Config{watchNamespace: ctrlcache.Config{}}
+		for _, ns := range additionalSourceNamespaces {
+			if ns = strings.TrimSpace(ns); ns != "" {
+				m[ns] = ctrlcache.Config{}
+			}
+		}
+		return m
+	}
+
+	opts.ByObject = map[ctrlclient.Object]ctrlcache.ByObject{
+		&sourcev1.GitRepository{}: {Namespaces: newSourceNamespaces()},
+		&sourcev1.Bucket{}:        {Namespaces: newSourceNamespaces()},
+		&sourcev1.OCIRepository{}: {Namespaces: newSourceNamespaces()},
+	}
+
+	return opts
+}
+
 func main() {
 	var (
-		metricsAddr               string
-		eventsAddr                string
-		healthAddr                string
-		concurrent                int
-		requeueDependency         time.Duration
-		clientOptions             client.Options
-		logOptions                logger.Options
-		leaderElectionOptions     leaderelection.Options
-		watchAllNamespaces        bool
-		httpRetry                 int
-		caValidityDuration        time.Duration
-		rotationCheckFrequency    time.Duration
-		runnerGRPCPort            int
-		runnerCreationTimeout     time.Duration
-		runnerGRPCMaxMessageSize  int
-		allowBreakTheGlass        bool
-		clusterDomain             string
-		aclOptions                acl.Options
-		allowCrossNamespaceRefs   bool
-		usePodSubdomainResolution bool
-		usePriorityQueue          bool
-		gracefulShutdownTimeout   time.Duration
-		quotaRetryEnabled         bool
-		quotaRetryDelay           time.Duration
-		quotaRetryJitterFactor    float64
+		metricsAddr                string
+		eventsAddr                 string
+		healthAddr                 string
+		concurrent                 int
+		requeueDependency          time.Duration
+		clientOptions              client.Options
+		logOptions                 logger.Options
+		leaderElectionOptions      leaderelection.Options
+		watchAllNamespaces         bool
+		additionalSourceNamespaces []string
+		httpRetry                  int
+		caValidityDuration         time.Duration
+		rotationCheckFrequency     time.Duration
+		runnerGRPCPort             int
+		runnerCreationTimeout      time.Duration
+		runnerGRPCMaxMessageSize   int
+		allowBreakTheGlass         bool
+		clusterDomain              string
+		aclOptions                 acl.Options
+		allowCrossNamespaceRefs    bool
+		usePodSubdomainResolution  bool
+		usePriorityQueue           bool
+		gracefulShutdownTimeout    time.Duration
+		quotaRetryEnabled          bool
+		quotaRetryDelay            time.Duration
+		quotaRetryJitterFactor     float64
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -111,6 +164,9 @@ func main() {
 	flag.DurationVar(&requeueDependency, "requeue-dependency", 30*time.Second, "The interval at which failing dependencies are reevaluated.")
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
+	flag.StringSliceVar(&additionalSourceNamespaces, "additional-source-namespaces", []string{},
+		"When --watch-all-namespaces=false, additional namespaces (besides the runtime namespace) from which "+
+			"source objects (GitRepository, Bucket, OCIRepository) may be read. No effect when watching all namespaces.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
 	flag.DurationVar(&caValidityDuration, "ca-cert-validity-duration", 24*7*time.Hour,
 		"The duration that the CA/mTLS certificates should be valid for. Default is 1 week.")
@@ -173,11 +229,7 @@ func main() {
 		},
 	}
 
-	if watchNamespace != "" {
-		mgrConfig.Cache.DefaultNamespaces = map[string]ctrlcache.Config{
-			watchNamespace: ctrlcache.Config{},
-		}
-	}
+	mgrConfig.Cache = buildCacheOptions(watchNamespace, additionalSourceNamespaces)
 
 	restConfig := client.GetConfigOrDie(clientOptions)
 	mgr, err := ctrl.NewManager(restConfig, mgrConfig)

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestBuildCacheOptions(t *testing.T) {
+	tests := []struct {
+		name                       string
+		watchNamespace             string
+		additionalSourceNamespaces []string
+		wantDefaultNamespaces      map[string]ctrlcache.Config
+		wantByObjectNamespaces     map[string]ctrlcache.Config // nil means ByObject must be unset entirely
+	}{
+		{
+			name:                       "watching all namespaces is a no-op regardless of additional namespaces",
+			watchNamespace:             "",
+			additionalSourceNamespaces: []string{"flux-system"},
+			wantDefaultNamespaces:      nil,
+			wantByObjectNamespaces:     nil,
+		},
+		{
+			name:                       "namespace-scoped with no additional namespaces matches today's behavior",
+			watchNamespace:             "dev",
+			additionalSourceNamespaces: nil,
+			wantDefaultNamespaces:      map[string]ctrlcache.Config{"dev": {}},
+			wantByObjectNamespaces:     nil,
+		},
+		{
+			name:                       "namespace-scoped with additional namespaces sets ByObject for source kinds only",
+			watchNamespace:             "dev",
+			additionalSourceNamespaces: []string{"flux-system"},
+			wantDefaultNamespaces:      map[string]ctrlcache.Config{"dev": {}},
+			wantByObjectNamespaces:     map[string]ctrlcache.Config{"dev": {}, "flux-system": {}},
+		},
+		{
+			name:                       "blank and whitespace-only entries are filtered out",
+			watchNamespace:             "dev",
+			additionalSourceNamespaces: []string{"flux-system", "", "   "},
+			wantDefaultNamespaces:      map[string]ctrlcache.Config{"dev": {}},
+			wantByObjectNamespaces:     map[string]ctrlcache.Config{"dev": {}, "flux-system": {}},
+		},
+		{
+			name:                       "an all-blank list behaves the same as no additional namespaces",
+			watchNamespace:             "dev",
+			additionalSourceNamespaces: []string{"", "  "},
+			wantDefaultNamespaces:      map[string]ctrlcache.Config{"dev": {}},
+			wantByObjectNamespaces:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildCacheOptions(tt.watchNamespace, tt.additionalSourceNamespaces)
+
+			if !reflect.DeepEqual(tt.wantDefaultNamespaces, got.DefaultNamespaces) {
+				t.Errorf("DefaultNamespaces = %#v, want %#v", got.DefaultNamespaces, tt.wantDefaultNamespaces)
+			}
+
+			if tt.wantByObjectNamespaces == nil {
+				if got.ByObject != nil {
+					t.Errorf("expected ByObject to be nil, got %#v", got.ByObject)
+				}
+				return
+			}
+
+			if got.ByObject == nil {
+				t.Fatalf("expected ByObject to be set for source kinds, got nil")
+			}
+
+			// ByObject is keyed by client.Object (an interface holding a pointer).
+			// Two separately-constructed &sourcev1.GitRepository{} values are
+			// DIFFERENT pointers, so map[key] lookups with a fresh pointer would
+			// never match — iterate and type-switch on the key instead.
+			seenKinds := map[string]bool{"GitRepository": false, "Bucket": false, "OCIRepository": false}
+			for obj, cfg := range got.ByObject {
+				var kind string
+				switch obj.(type) {
+				case *sourcev1.GitRepository:
+					kind = "GitRepository"
+				case *sourcev1.Bucket:
+					kind = "Bucket"
+				case *sourcev1.OCIRepository:
+					kind = "OCIRepository"
+				default:
+					t.Fatalf("unexpected ByObject key type %T", obj)
+				}
+				seenKinds[kind] = true
+				if !reflect.DeepEqual(tt.wantByObjectNamespaces, cfg.Namespaces) {
+					t.Errorf("ByObject[%s].Namespaces = %#v, want %#v", kind, cfg.Namespaces, tt.wantByObjectNamespaces)
+				}
+			}
+			for kind, seen := range seenKinds {
+				if !seen {
+					t.Errorf("missing ByObject entry for %s", kind)
+				}
+			}
+		})
+	}
+}
+
+// distinctMapInstances guards against a subtle regression: buildCacheOptions
+// must give each ByObject entry its own Namespaces map instance, not a shared
+// one, because controller-runtime's option-defaulting mutates Config values
+// in place — sharing one map across GitRepository/Bucket/OCIRepository would
+// mean a mutation intended for one GVK silently leaks into the others.
+func TestBuildCacheOptionsDistinctMapInstances(t *testing.T) {
+	got := buildCacheOptions("dev", []string{"flux-system"})
+	seen := map[*ctrlclient.Object]bool{}
+	var namespaceMaps []map[string]ctrlcache.Config
+	for _, cfg := range got.ByObject {
+		namespaceMaps = append(namespaceMaps, cfg.Namespaces)
+	}
+	if len(namespaceMaps) != 3 {
+		t.Fatalf("expected 3 ByObject entries, got %d", len(namespaceMaps))
+	}
+	for i := 0; i < len(namespaceMaps); i++ {
+		for j := i + 1; j < len(namespaceMaps); j++ {
+			// reflect on the map header pointer via a mutation probe: mutate one
+			// and confirm the others are unaffected.
+			namespaceMaps[i]["probe"] = ctrlcache.Config{}
+			if _, leaked := namespaceMaps[j]["probe"]; leaked {
+				t.Fatalf("Namespaces map instance is shared across ByObject entries — mutation leaked")
+			}
+			delete(namespaceMaps[i], "probe")
+		}
+	}
+	_ = seen
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -89,7 +89,7 @@ func TestMain(m *testing.M) {
 		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
-	cfg, err := testEnv.Start()
+	cfg, err = testEnv.Start()
 	if err != nil {
 		panic(err.Error())
 	}

--- a/controllers/tc000363_additional_source_namespaces_test.go
+++ b/controllers/tc000363_additional_source_namespaces_test.go
@@ -1,0 +1,129 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	infrav1 "github.com/flux-iac/tofu-controller/api/v1alpha2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Note: infrav1 must be imported explicitly in THIS file even though other
+// files in the same `controllers` package already import it — Go import
+// visibility is per-file, not per-package.
+
+// Test_000363_AdditionalSourceNamespaces proves the exact mechanism this PR
+// relies on: a cache scoped to one namespace via DefaultNamespaces, with
+// ByObject widening ONLY the GitRepository kind to an additional namespace,
+// correctly (a) allows reading GitRepository objects in that additional
+// namespace, (b) still refuses to read Terraform-kind objects there
+// (isolation preserved — this is the property that ruled out the
+// alternative "just widen DefaultNamespaces" design), and (c) still refuses
+// to read GitRepository objects in a third, unlisted namespace (no
+// accidental over-broadening).
+func Test_000363_AdditionalSourceNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const (
+		shardNS = "test-shard-a"
+		srcNS   = "test-flux-system"
+		otherNS = "test-other-ns"
+	)
+
+	for _, ns := range []string{shardNS, srcNS, otherNS} {
+		g.Expect(k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		})).To(Succeed())
+	}
+
+	srcInAdditionalNS := &sourcev1.GitRepository{
+		ObjectMeta: metav1.ObjectMeta{Name: "src-in-additional-ns", Namespace: srcNS},
+		Spec: sourcev1.GitRepositorySpec{
+			URL:      "https://github.com/flux-iac/tofu-controller",
+			Interval: metav1.Duration{Duration: time.Hour},
+		},
+	}
+	g.Expect(k8sClient.Create(ctx, srcInAdditionalNS)).To(Succeed())
+
+	tfInAdditionalNS := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{Name: "tf-in-additional-ns", Namespace: srcNS},
+		Spec: infrav1.TerraformSpec{
+			ApprovePlan: infrav1.ApprovePlanAutoValue,
+			Interval:    metav1.Duration{Duration: time.Hour},
+			SourceRef: infrav1.CrossNamespaceSourceReference{
+				Kind: "GitRepository",
+				Name: "src-in-additional-ns",
+			},
+		},
+	}
+	g.Expect(k8sClient.Create(ctx, tfInAdditionalNS)).To(Succeed())
+
+	srcInOtherNS := &sourcev1.GitRepository{
+		ObjectMeta: metav1.ObjectMeta{Name: "src-in-other-ns", Namespace: otherNS},
+		Spec: sourcev1.GitRepositorySpec{
+			URL:      "https://github.com/flux-iac/tofu-controller",
+			Interval: metav1.Duration{Duration: time.Hour},
+		},
+	}
+	g.Expect(k8sClient.Create(ctx, srcInOtherNS)).To(Succeed())
+
+	// This cache is built with its own scheme, deliberately separate from
+	// TestMain's manager/reconciler setup — TestMain's scheme is a
+	// function-local variable there, not shared package state, and this
+	// test is designed to be fully self-contained rather than reach into
+	// TestMain's internals. It registers the same types TestMain's scheme
+	// does (client-go's scheme, source-controller's API, and this
+	// controller's API).
+	scheme := runtime.NewScheme()
+	g.Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	g.Expect(sourcev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(infrav1.AddToScheme(scheme)).To(Succeed())
+
+	scopedCache, err := cache.New(cfg, cache.Options{
+		Scheme: scheme,
+		DefaultNamespaces: map[string]cache.Config{
+			shardNS: {},
+		},
+		ByObject: map[client.Object]cache.ByObject{
+			&sourcev1.GitRepository{}: {
+				Namespaces: map[string]cache.Config{shardNS: {}, srcNS: {}},
+			},
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cacheCtx, cacheCancel := context.WithCancel(ctx)
+	defer cacheCancel()
+	go func() {
+		_ = scopedCache.Start(cacheCtx)
+	}()
+	g.Expect(scopedCache.WaitForCacheSync(cacheCtx)).To(BeTrue())
+
+	// (a) a GitRepository in the additional namespace IS readable — the fix working.
+	var gotSrc sourcev1.GitRepository
+	g.Expect(scopedCache.Get(ctx, types.NamespacedName{Namespace: srcNS, Name: "src-in-additional-ns"}, &gotSrc)).To(Succeed())
+
+	// (b) a Terraform CR in that SAME additional namespace is NOT readable —
+	// reconcile-scope isolation preserved, even though its namespace is
+	// readable for GitRepository purposes.
+	var gotTF infrav1.Terraform
+	err = scopedCache.Get(ctx, types.NamespacedName{Namespace: srcNS, Name: "tf-in-additional-ns"}, &gotTF)
+	g.Expect(err).To(HaveOccurred())
+
+	// (c) a GitRepository in a third, UNLISTED namespace is still NOT
+	// readable — no accidental over-broadening beyond what was configured.
+	var gotOtherSrc sourcev1.GitRepository
+	err = scopedCache.Get(ctx, types.NamespacedName{Namespace: otherNS, Name: "src-in-other-ns"}, &gotOtherSrc)
+	g.Expect(err).To(HaveOccurred())
+}


### PR DESCRIPTION
## Problem

`--watch-all-namespaces=false` (used to run namespace-scoped instances instead of one instance watching a whole cluster) scopes the manager's entire object cache to one namespace — not just which `Terraform` CRs get reconciled, but also which namespaces `GitRepository`/`Bucket`/`OCIRepository` sources can be read from. In real-world use these sources are centralized in one namespace (e.g. `flux-system`) and referenced by CRs across every other namespace, so a namespace-scoped instance fails to resolve almost every CR's source with `unknown namespace for the cache`. This isn't an RBAC issue (the ClusterRole already grants cluster-wide access to these kinds) and isn't affected by `--allow-cross-namespace-refs` (that flag only gates an access-control check before the read is attempted — it doesn't change what the cache can serve).

## Fix

A new `--additional-source-namespaces` flag (and matching `additionalSourceNamespaces` Helm value) lets a namespace-scoped instance additionally read `GitRepository`/`Bucket`/`OCIRepository` objects from other namespaces, using controller-runtime's `Cache.Options.ByObject[...].Namespaces` to scope *only those three kinds* — `Terraform` CR reconciliation stays exactly as namespace-scoped as it is today. This also restores the source-change watch trigger for the additional namespaces (`Watches()` on the source kinds is cache-backed the same way `Get()` is), which a purely read-side fix (e.g. an uncached read) would not.

Fully backward compatible: the new flag defaults to empty, and is a guaranteed no-op both when unset and when `--watch-all-namespaces=true`.

## Testing

- Unit tests for the cache-options construction logic, including the no-op guards and blank-entry filtering (`cmd/manager/main_test.go`).
- An integration test against a real cache (via envtest) proving: a source in the additional namespace is readable, a `Terraform` CR in that same namespace is *not* readable (reconcile-scope isolation preserved), and a source in a third, unlisted namespace is *not* readable (no accidental over-broadening) (`controllers/tc000363_additional_source_namespaces_test.go`).

## Out of scope

Cross-namespace `dependsOn` (`Terraform` → `Terraform` references) hits the same underlying cache-scope limitation but is a separate reference type resolved by different code — left for a follow-up PR using the same technique.
