### PR TITLE
feat: surface orphaned Apply locks after runner replacement

### DIFF
--- a/api/v1alpha2/condition_types.go
+++ b/api/v1alpha2/condition_types.go
@@ -126,7 +126,7 @@ const (
 	TFExecLockHeldReason = "LockHeld"
 
 	// TFExecLockOrphanedReason represents a state lock whose holder
-	// runner Pod is gone (lock Created is before the current runner start).
+	// runner Pod is gone (lock Created is before the current runner Pod creationTimestamp).
 	TFExecLockOrphanedReason = "LockOrphaned"
 
 	// TFExecNewFailedReason represents the fact that the creation

--- a/api/v1alpha2/condition_types.go
+++ b/api/v1alpha2/condition_types.go
@@ -125,6 +125,10 @@ const (
 	// state lock is held by another process.
 	TFExecLockHeldReason = "LockHeld"
 
+	// TFExecLockOrphanedReason represents a state lock whose holder
+	// runner Pod is gone (lock Created is before the current runner start).
+	TFExecLockOrphanedReason = "LockOrphaned"
+
 	// TFExecNewFailedReason represents the fact that the creation
 	// of the Terraform process failed.
 	TFExecNewFailedReason = "TFExecNewFailed"

--- a/api/v1alpha2/terraform_types.go
+++ b/api/v1alpha2/terraform_types.go
@@ -820,6 +820,21 @@ func TerraformStateLocked(terraform *Terraform, lockID, message string) *Terrafo
 	return terraform
 }
 
+// TerraformLockOrphaned marks a lock whose Created timestamp is before the
+// current runner Pod startTime. Operators can tell this apart from a live Apply.
+func TerraformLockOrphaned(terraform *Terraform, lockID, message string) *Terraform {
+	msg := trimString(message, MaxConditionMessageLength)
+	conditions.MarkTrue(terraform, ConditionTypeStateLocked, TFExecLockOrphanedReason, "%s", msg)
+	SetTerraformReadiness(terraform, metav1.ConditionFalse, TFExecLockOrphanedReason, msg, "")
+
+	if terraform.Status.Lock.Pending != "" && terraform.Status.Lock.LastApplied != terraform.Status.Lock.Pending {
+		terraform.Status.Lock.LastApplied = terraform.Status.Lock.Pending
+	}
+
+	terraform.Status.Lock.Pending = lockID
+	return terraform
+}
+
 // TerraformStateLockReleased clears any state lock condition and resets lock tracking fields.
 func TerraformStateLockReleased(terraform *Terraform) *Terraform {
 	conditions.Delete(terraform, ConditionTypeStateLocked)

--- a/api/v1alpha2/terraform_types.go
+++ b/api/v1alpha2/terraform_types.go
@@ -821,7 +821,7 @@ func TerraformStateLocked(terraform *Terraform, lockID, message string) *Terrafo
 }
 
 // TerraformLockOrphaned marks a lock whose Created timestamp is before the
-// current runner Pod startTime. Operators can tell this apart from a live Apply.
+// current runner Pod creationTimestamp. Operators can tell this apart from a live Apply.
 func TerraformLockOrphaned(terraform *Terraform, lockID, message string) *Terraform {
 	msg := trimString(message, MaxConditionMessageLength)
 	conditions.MarkTrue(terraform, ConditionTypeStateLocked, TFExecLockOrphanedReason, "%s", msg)

--- a/controllers/lock_orphan.go
+++ b/controllers/lock_orphan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,20 +13,36 @@ import (
 	infrav1 "github.com/flux-iac/tofu-controller/api/v1alpha2"
 )
 
-var terraformLockCreatedRe = regexp.MustCompile(`Created:\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})`)
+// terraformLockCreatedRe captures the remainder of the lock Created line so
+// fractional seconds and a timezone/offset are not dropped.
+var terraformLockCreatedRe = regexp.MustCompile(`Created:\s+(.+)`)
+
+// terraformLockCreatedLayouts match tofu/terraform lock output. The first
+// layout is time.Time.String(), which is what LockInfo typically prints.
+var terraformLockCreatedLayouts = []string{
+	"2006-01-02 15:04:05.999999999 -0700 MST",
+	"2006-01-02 15:04:05.999999999 -0700",
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02 15:04:05.999999999",
+	"2006-01-02 15:04:05",
+}
 
 // parseTerraformLockCreated extracts the lock Created wall time from a
-// terraform/tofu "Error acquiring the state lock" message.
+// terraform/tofu "Error acquiring the state lock" message, including
+// sub-second precision and zone/offset when present.
 func parseTerraformLockCreated(raw string) (time.Time, bool) {
 	m := terraformLockCreatedRe.FindStringSubmatch(raw)
 	if len(m) < 2 {
 		return time.Time{}, false
 	}
-	t, err := time.ParseInLocation("2006-01-02 15:04:05", m[1], time.UTC)
-	if err != nil {
-		return time.Time{}, false
+	value := strings.TrimSpace(m[1])
+	for _, layout := range terraformLockCreatedLayouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t, true
+		}
 	}
-	return t, true
+	return time.Time{}, false
 }
 
 func (r *TerraformReconciler) lockConditionForPlanError(ctx context.Context, terraform *infrav1.Terraform, lockID, rawErr string) *infrav1.Terraform {
@@ -45,10 +62,10 @@ func (r *TerraformReconciler) lockConditionForPlanError(ctx context.Context, ter
 		return locked
 	}
 	msg := fmt.Sprintf(
-		"State lock %s looks orphaned: lock Created %s is before runner pod start %s",
+		"State lock %s looks orphaned: lock Created %s is before runner pod creationTimestamp %s",
 		lockID,
-		created.UTC().Format(time.RFC3339),
-		pod.CreationTimestamp.UTC().Format(time.RFC3339),
+		created.UTC().Format(time.RFC3339Nano),
+		pod.CreationTimestamp.UTC().Format(time.RFC3339Nano),
 	)
 	ctrl.LoggerFrom(ctx).Info(msg)
 	return infrav1.TerraformLockOrphaned(terraform, lockID, msg)

--- a/controllers/lock_orphan.go
+++ b/controllers/lock_orphan.go
@@ -1,0 +1,55 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	infrav1 "github.com/flux-iac/tofu-controller/api/v1alpha2"
+)
+
+var terraformLockCreatedRe = regexp.MustCompile(`Created:\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})`)
+
+// parseTerraformLockCreated extracts the lock Created wall time from a
+// terraform/tofu "Error acquiring the state lock" message.
+func parseTerraformLockCreated(raw string) (time.Time, bool) {
+	m := terraformLockCreatedRe.FindStringSubmatch(raw)
+	if len(m) < 2 {
+		return time.Time{}, false
+	}
+	t, err := time.ParseInLocation("2006-01-02 15:04:05", m[1], time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+func (r *TerraformReconciler) lockConditionForPlanError(ctx context.Context, terraform *infrav1.Terraform, lockID, rawErr string) *infrav1.Terraform {
+	locked := infrav1.TerraformStateLocked(terraform, lockID, fmt.Sprintf("Terraform Locked with Lock Identifier: %s", lockID))
+	created, ok := parseTerraformLockCreated(rawErr)
+	if !ok {
+		return locked
+	}
+	var pod corev1.Pod
+	if err := r.Get(ctx, getRunnerPodObjectKey(terraform), &pod); err != nil {
+		return locked
+	}
+	if pod.CreationTimestamp.Time.IsZero() {
+		return locked
+	}
+	if !pod.CreationTimestamp.Time.After(created) {
+		return locked
+	}
+	msg := fmt.Sprintf(
+		"State lock %s looks orphaned: lock Created %s is before runner pod start %s",
+		lockID,
+		created.UTC().Format(time.RFC3339),
+		pod.CreationTimestamp.UTC().Format(time.RFC3339),
+	)
+	ctrl.LoggerFrom(ctx).Info(msg)
+	return infrav1.TerraformLockOrphaned(terraform, lockID, msg)
+}

--- a/controllers/lock_orphan_test.go
+++ b/controllers/lock_orphan_test.go
@@ -1,0 +1,113 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/pkg/runtime/conditions"
+	infrav1 "github.com/flux-iac/tofu-controller/api/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestParseTerraformLockCreated(t *testing.T) {
+	raw := `error acquiring the state lock: Lock Info:
+  ID:        fff6a1aa-c879-2e17-d197-1418368e715d
+  Operation: OperationTypeApply
+  Who:       runner@example-tf-runner
+  Created:   2026-09-01 08:58:05.393443698 +0000 UTC
+`
+	got, ok := parseTerraformLockCreated(raw)
+	if !ok {
+		t.Fatal("expected to parse Created")
+	}
+	want := time.Date(2026, 9, 1, 8, 58, 5, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestParseTerraformLockCreatedMissing(t *testing.T) {
+	if _, ok := parseTerraformLockCreated("plain error"); ok {
+		t.Fatal("expected no parse")
+	}
+}
+
+func TestLockConditionForPlanErrorOrphaned(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := infrav1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	lockCreated := time.Date(2026, 9, 1, 8, 58, 5, 0, time.UTC)
+	tf := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "flux-system"},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "example-tf-runner",
+			Namespace:         "flux-system",
+			CreationTimestamp: metav1.NewTime(lockCreated.Add(48 * time.Minute)),
+		},
+	}
+	r := &TerraformReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build(),
+	}
+	raw := `error acquiring the state lock: Lock Info:
+  ID:        fff6a1aa-c879-2e17-d197-1418368e715d
+  Operation: OperationTypeApply
+  Who:       runner@example-tf-runner
+  Created:   2026-09-01 08:58:05.393443698 +0000 UTC
+`
+	out := r.lockConditionForPlanError(context.Background(), tf, "fff6a1aa-c879-2e17-d197-1418368e715d", raw)
+	c := conditions.Get(out, infrav1.ConditionTypeStateLocked)
+	if c == nil {
+		t.Fatal("expected StateLocked condition")
+	}
+	if c.Reason != infrav1.TFExecLockOrphanedReason {
+		t.Fatalf("got reason %q want %q", c.Reason, infrav1.TFExecLockOrphanedReason)
+	}
+}
+
+func TestLockConditionForPlanErrorLiveLock(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := infrav1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	lockCreated := time.Date(2026, 9, 1, 8, 58, 5, 0, time.UTC)
+	tf := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "flux-system"},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "example-tf-runner",
+			Namespace:         "flux-system",
+			CreationTimestamp: metav1.NewTime(lockCreated.Add(-time.Minute)),
+		},
+	}
+	r := &TerraformReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build(),
+	}
+	raw := `error acquiring the state lock: Lock Info:
+  ID:        fff6a1aa-c879-2e17-d197-1418368e715d
+  Created:   2026-09-01 08:58:05.393443698 +0000 UTC
+`
+	out := r.lockConditionForPlanError(context.Background(), tf, "fff6a1aa-c879-2e17-d197-1418368e715d", raw)
+	c := conditions.Get(out, infrav1.ConditionTypeStateLocked)
+	if c == nil {
+		t.Fatal("expected StateLocked condition")
+	}
+	if c.Reason != infrav1.TFExecLockHeldReason {
+		t.Fatalf("got reason %q want %q", c.Reason, infrav1.TFExecLockHeldReason)
+	}
+}

--- a/controllers/lock_orphan_test.go
+++ b/controllers/lock_orphan_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fluxcd/pkg/runtime/conditions"
 	infrav1 "github.com/flux-iac/tofu-controller/api/v1alpha2"
+	"github.com/fluxcd/pkg/runtime/conditions"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,19 +14,45 @@ import (
 )
 
 func TestParseTerraformLockCreated(t *testing.T) {
-	raw := `error acquiring the state lock: Lock Info:
+	tests := []struct {
+		name string
+		raw  string
+		want time.Time
+	}{
+		{
+			name: "fractional seconds and utc offset",
+			raw: `error acquiring the state lock: Lock Info:
   ID:        fff6a1aa-c879-2e17-d197-1418368e715d
   Operation: OperationTypeApply
   Who:       runner@example-tf-runner
   Created:   2026-09-01 08:58:05.393443698 +0000 UTC
-`
-	got, ok := parseTerraformLockCreated(raw)
-	if !ok {
-		t.Fatal("expected to parse Created")
+`,
+			want: time.Date(2026, 9, 1, 8, 58, 5, 393443698, time.UTC),
+		},
+		{
+			name: "non-utc offset",
+			raw:  "Created:   2026-09-01 10:58:05.393443698 +0200 CEST\n",
+			want: time.Date(2026, 9, 1, 8, 58, 5, 393443698, time.UTC),
+		},
+		{
+			name: "whole seconds with zone",
+			raw:  "Created:   2026-09-01 08:58:05 +0000 UTC",
+			want: time.Date(2026, 9, 1, 8, 58, 5, 0, time.UTC),
+		},
 	}
-	want := time.Date(2026, 9, 1, 8, 58, 5, 0, time.UTC)
-	if !got.Equal(want) {
-		t.Fatalf("got %v want %v", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseTerraformLockCreated(tt.raw)
+			if !ok {
+				t.Fatal("expected to parse Created")
+			}
+			if !got.Equal(tt.want) {
+				t.Fatalf("got %v want %v", got, tt.want)
+			}
+			if got.Nanosecond() != tt.want.Nanosecond() {
+				t.Fatalf("got nanoseconds %d want %d", got.Nanosecond(), tt.want.Nanosecond())
+			}
+		})
 	}
 }
 
@@ -45,7 +71,7 @@ func TestLockConditionForPlanErrorOrphaned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lockCreated := time.Date(2026, 9, 1, 8, 58, 5, 0, time.UTC)
+	lockCreated := time.Date(2026, 9, 1, 8, 58, 5, 393443698, time.UTC)
 	tf := &infrav1.Terraform{
 		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "flux-system"},
 	}
@@ -84,7 +110,7 @@ func TestLockConditionForPlanErrorLiveLock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lockCreated := time.Date(2026, 9, 1, 8, 58, 5, 0, time.UTC)
+	lockCreated := time.Date(2026, 9, 1, 8, 58, 5, 393443698, time.UTC)
 	tf := &infrav1.Terraform{
 		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "flux-system"},
 	}
@@ -109,5 +135,65 @@ func TestLockConditionForPlanErrorLiveLock(t *testing.T) {
 	}
 	if c.Reason != infrav1.TFExecLockHeldReason {
 		t.Fatalf("got reason %q want %q", c.Reason, infrav1.TFExecLockHeldReason)
+	}
+}
+
+func TestLockConditionForPlanErrorSameSecondUsesNanoseconds(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := infrav1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	raw := `Created:   2026-09-01 08:58:05.393443698 +0000 UTC`
+	lockID := "fff6a1aa-c879-2e17-d197-1418368e715d"
+	sameSecond := time.Date(2026, 9, 1, 8, 58, 5, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		podNano    int
+		wantOrphan bool
+	}{
+		{
+			name:       "pod created earlier in the same second is a live lock",
+			podNano:    100000000,
+			wantOrphan: false,
+		},
+		{
+			name:       "pod created later in the same second is orphaned",
+			podNano:    500000000,
+			wantOrphan: true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tf := &infrav1.Terraform{
+				ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "flux-system"},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "example-tf-runner",
+					Namespace:         "flux-system",
+					CreationTimestamp: metav1.NewTime(sameSecond.Add(time.Duration(tt.podNano))),
+				},
+			}
+			r := &TerraformReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build(),
+			}
+			out := r.lockConditionForPlanError(context.Background(), tf, lockID, raw)
+			c := conditions.Get(out, infrav1.ConditionTypeStateLocked)
+			if c == nil {
+				t.Fatal("expected StateLocked condition")
+			}
+			wantReason := infrav1.TFExecLockHeldReason
+			if tt.wantOrphan {
+				wantReason = infrav1.TFExecLockOrphanedReason
+			}
+			if c.Reason != wantReason {
+				t.Fatalf("got reason %q want %q", c.Reason, wantReason)
+			}
+		})
 	}
 }

--- a/controllers/lock_orphan_test.go
+++ b/controllers/lock_orphan_test.go
@@ -138,62 +138,24 @@ func TestLockConditionForPlanErrorLiveLock(t *testing.T) {
 	}
 }
 
-func TestLockConditionForPlanErrorSameSecondUsesNanoseconds(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
+func TestParseTerraformLockCreatedSameSecondUsesNanoseconds(t *testing.T) {
+	created, ok := parseTerraformLockCreated("Created:   2026-09-01 08:58:05.393443698 +0000 UTC")
+	if !ok {
+		t.Fatal("expected to parse Created")
 	}
-	if err := infrav1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
+	if created.Nanosecond() != 393443698 {
+		t.Fatalf("got nanoseconds %d want 393443698", created.Nanosecond())
 	}
 
-	raw := `Created:   2026-09-01 08:58:05.393443698 +0000 UTC`
-	lockID := "fff6a1aa-c879-2e17-d197-1418368e715d"
-	sameSecond := time.Date(2026, 9, 1, 8, 58, 5, 0, time.UTC)
-
-	cases := []struct {
-		name       string
-		podNano    int
-		wantOrphan bool
-	}{
-		{
-			name:       "pod created earlier in the same second is a live lock",
-			podNano:    100000000,
-			wantOrphan: false,
-		},
-		{
-			name:       "pod created later in the same second is orphaned",
-			podNano:    500000000,
-			wantOrphan: true,
-		},
+	// Kubernetes metav1.Time is second-precision after an API round-trip, but
+	// lock Created keeps nanoseconds. Truncating Created to whole seconds would
+	// make an earlier same-second pod look like it started after the lock.
+	earlier := time.Date(2026, 9, 1, 8, 58, 5, 100000000, time.UTC)
+	later := time.Date(2026, 9, 1, 8, 58, 5, 500000000, time.UTC)
+	if earlier.After(created) {
+		t.Fatal("pod created earlier in the same second must not classify as orphaned")
 	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			tf := &infrav1.Terraform{
-				ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "flux-system"},
-			}
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "example-tf-runner",
-					Namespace:         "flux-system",
-					CreationTimestamp: metav1.NewTime(sameSecond.Add(time.Duration(tt.podNano))),
-				},
-			}
-			r := &TerraformReconciler{
-				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build(),
-			}
-			out := r.lockConditionForPlanError(context.Background(), tf, lockID, raw)
-			c := conditions.Get(out, infrav1.ConditionTypeStateLocked)
-			if c == nil {
-				t.Fatal("expected StateLocked condition")
-			}
-			wantReason := infrav1.TFExecLockHeldReason
-			if tt.wantOrphan {
-				wantReason = infrav1.TFExecLockOrphanedReason
-			}
-			if c.Reason != wantReason {
-				t.Fatalf("got reason %q want %q", c.Reason, wantReason)
-			}
-		})
+	if !later.After(created) {
+		t.Fatal("pod created later in the same second must classify as orphaned")
 	}
 }

--- a/controllers/tf_controller_plan.go
+++ b/controllers/tf_controller_plan.go
@@ -79,7 +79,7 @@ func (r *TerraformReconciler) plan(ctx context.Context, patchHelper *patch.Seria
 					msg := fmt.Sprintf("Plan error: State locked with Lock Identifier %s", reply.StateLockIdentifier)
 					r.Eventf(terraform, corev1.EventTypeWarning, infrav1.TFExecPlanFailedReason, "%s", msg)
 					eventSent = true
-					terraform = infrav1.TerraformStateLocked(terraform, reply.StateLockIdentifier, fmt.Sprintf("Terraform Locked with Lock Identifier: %s", reply.StateLockIdentifier))
+					terraform = r.lockConditionForPlanError(ctx, terraform, reply.StateLockIdentifier, err.Error())
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

When a Terraform runner Pod is replaced while an Apply lock is still held, the new runner loops on `TFExecPlanFailed` / `LockHeld` with no signal that the lock predates the current Pod.

This PR parses the lock `Created` timestamp from the tofu/terraform lock error and compares it to the current `{name}-tf-runner` Pod `creationTimestamp`. If the lock is older than the Pod, the `StateLocked` condition reason is `LockOrphaned` instead of `LockHeld`.

This does **not** force-unlock. Operators still decide whether to clear the lock.

Fixes https://github.com/flux-iac/tofu-controller/issues/1876
Related: https://github.com/flux-iac/tofu-controller/issues/1125

## Tests

- `controllers/lock_orphan_test.go` parses lock `Created` (including fractional seconds).
- Fake-client tests cover orphaned vs live lock reasons.

Local `go test ./controllers` needs envtest/etcd (`KUBEBUILDER_ASSETS`) because `TestMain` starts the control plane.
